### PR TITLE
fix error for std::memcpy by including cstring on linux

### DIFF
--- a/src/external_copy.cc
+++ b/src/external_copy.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "external_copy.h"
 
 #include "util.h"


### PR DESCRIPTION
Started getting:

```
../src/external_copy.cc:254:2: error: ‘memcpy’ is not a member of ‘std’
```

Fixed by including `<cstring>` in `src/external_copy.cc`