### PR TITLE
Updated and corrected typescript definitions

### DIFF
--- a/src/reference_handle.cc
+++ b/src/reference_handle.cc
@@ -74,7 +74,7 @@ Local<FunctionTemplate> ReferenceHandle::Definition() {
 		"apply", Parameterize<decltype(&ReferenceHandle::Apply<1>), &ReferenceHandle::Apply<1>>(),
 		"applyIgnored", Parameterize<decltype(&ReferenceHandle::Apply<2>), &ReferenceHandle::Apply<2>>(),
 		"applySync", Parameterize<decltype(&ReferenceHandle::Apply<0>), &ReferenceHandle::Apply<0>>(),
-		"tyepof", ParameterizeAccessor<decltype(&ReferenceHandle::TypeOfGetter), &ReferenceHandle::TypeOfGetter>()
+		"typeof", ParameterizeAccessor<decltype(&ReferenceHandle::TypeOfGetter), &ReferenceHandle::TypeOfGetter>()
 	));
 }
 


### PR DESCRIPTION
- Adds the NativeModule type
- Adds Transferable, a union type representing all transferable types
- Adds Copy<T>, a value that's been copied into another isolate
- Made arguments to `apply` functions optional

If I'm missing any Transferable types, I'd love to add them. Makes our logic a bit more robust :)