### PR TITLE
Fixes a memory leak, Reference disposition also needs to reset v8::Persistent

### DIFF
--- a/src/reference_handle.cc
+++ b/src/reference_handle.cc
@@ -146,6 +146,7 @@ Local<Value> ReferenceHandle::DerefInto() {
 Local<Value> ReferenceHandle::Dispose() {
 	CheckDisposed();
 	isolate.reset();
+	reference->Reset();
 	reference.reset();
 	context.reset();
 	return Undefined(Isolate::GetCurrent());

--- a/tests/context-leak.js
+++ b/tests/context-leak.js
@@ -1,8 +1,15 @@
 'use strict';
 let ivm = require('isolated-vm');
-let isolate = new ivm.Isolate({ memoryLimit: 32 });
+let snapshot = ivm.Isolate.createSnapshot([
+	{ code: "function fn(){};" }
+])
+let isolate = new ivm.Isolate({ memoryLimit: 32, snapshot });
 for (let ii = 0; ii < 500; ++ii) {
 	let context = isolate.createContextSync();
+	let g = context.globalReference()
+	let fn = g.getSync("fn")
+	g.dispose()
+	fn.dispose()
 	context.release();
 }
 console.log('pass');


### PR DESCRIPTION
- Added a more realistic test case that failed before
- `v8::Persistent` needs to be reset, not only the pointer's ownership (as far as I understand)

This does not solve our bigger leak issue, but I think it's a step in the right direction.