### PR TITLE
Support for ES6 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 node_modules/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/
 node_modules/
-.idea

--- a/README.md
+++ b/README.md
@@ -236,12 +236,11 @@ is the last expression.
 
 
 ### Class: `Module` *[transferable]*
-A JavaScript module. Note that a [`Module`](#class-module-transferable) can only run in the isolate which created it and once instantiated,
-can it only be used within that [`context`](#class-context-transferable).
+A JavaScript module. Note that a [`Module`](#class-module-transferable) can only run in the isolate which created it.
 
 
 ##### `module.dependencySpecifiers`
-An read-only array of all dependency specifiers the module has.
+A read-only array of all dependency specifiers the module has.
 
     const code = `import something from './something';`;
     const module = await isolate.compileModule(code);
@@ -253,19 +252,19 @@ An read-only array of all dependency specifiers the module has.
 * `module` - Another *[`Module`](#class-module-transferable)* instance.
 * **return** *[undefined]*
 
-Set the dependency the referrer-module should resolve use when [specifier] is requested.
+Set the dependency the referrer-module should resolve use when [specifier] is requested. Module
+must belong to the same context if it has already been instantiated.
 
 ##### `module.instantiate(context)` *[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)*
 ##### `module.instantiateSync(context)`
 * `context` *[`Context`](#class-context-transferable)* - The context the module should use.
 * **return** *[boolean]*
 
-Instantiate the module together will all its dependencies.
+Instantiate the module together with all its dependencies.
 
-##### `module.evaluate(context, options)` *[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)*
-##### `module.evaluateSync(context)`
-* `context` *[`Context`](#class-context-transferable)* - The context the module should use.
-* `options` *[object]*
+##### `module.evaluate(options)` *[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)*
+##### `module.evaluateSync(options)`
+* `options` *[object]* - Optional.
 	* `timeout` *[number]* - Maximum amount of time this module is allowed to run before execution is
 	canceled. Default is no timeout.
 * **return** last expression
@@ -275,30 +274,6 @@ Evaluate the module and return the last expression (same as script.run).
 
 ##### `module.namespace`
 Returns a [`Reference`](#class-reference-transferable) containing all exported values.
-
-There is currently a minor bug that causes "let" variables to be copied and behave as "const".
-The code below will not work:
-
-    // create isolare and context...
-    const code = `
-        export let value = 0;
-        export const change = val => {
-            value += val;
-            return value;
-        };
-    `;
-    const module = isolate.compileModuleSync(code);
-    module.instantiateSync(context);
-    module.evaluateSync();
-    const reference = module.namespace;
-    const value = reference.getSync('value');
-    const change = reference.getSync('change');
-    console.log(value.copySync());                      // will print 0 because add have not yet changed the value
-    const returnValue = change.applySync(null, [123]);  // call the module export "change" with the value: 123
-    console.log(returnValue)                            // print 123 as ecpected
-    console.log(value.copySync())                       // will print 0 because of the bug, even if "123" is the expected value
-
-    // To receive the "current" value, do: reference.getSync('value').copySync()
 
 
 ### Class: `Reference` *[transferable]*

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ must belong to the same context if it has already been instantiated.
 ##### `module.instantiate(context)` *[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)*
 ##### `module.instantiateSync(context)`
 * `context` *[`Context`](#class-context-transferable)* - The context the module should use.
-* **return** *[boolean]*
+* **return** *[undefined]*
 
 Instantiate the module together with all its dependencies.
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -60,6 +60,7 @@
 				'src/native_module_handle.cc',
 				'src/reference_handle.cc',
 				'src/script_handle.cc',
+				'src/module_handle.cc',
 				'src/session_handle.cc',
 				'src/transferable.cc',
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "isolated-vm",
+  "version": "1.6.1",
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "isolated-vm",
-  "version": "1.6.1",
-  "lockfileVersion": 1
-}

--- a/src/context_handle.h
+++ b/src/context_handle.h
@@ -10,6 +10,7 @@ namespace ivm {
 class ContextHandle : public TransferableHandle {
 	friend struct RunRunner;
 	friend struct InstantiateRunner;
+	friend struct EvaluateRunner;
 	friend class NativeModuleHandle;
 	private:
 		std::shared_ptr<RemoteHandle<v8::Context>> context;

--- a/src/context_handle.h
+++ b/src/context_handle.h
@@ -9,6 +9,7 @@ namespace ivm {
 
 class ContextHandle : public TransferableHandle {
 	friend struct RunRunner;
+	friend struct InstantiateRunner;
 	friend class NativeModuleHandle;
 	private:
 		std::shared_ptr<RemoteHandle<v8::Context>> context;

--- a/src/context_handle.h
+++ b/src/context_handle.h
@@ -10,8 +10,6 @@ namespace ivm {
 class ContextHandle : public TransferableHandle {
 	friend struct RunRunner;
 	friend struct InstantiateRunner;
-	friend struct EvaluateRunner;
-	friend struct GetModuleNamespaceRunner;
 	friend class NativeModuleHandle;
 	private:
 		std::shared_ptr<RemoteHandle<v8::Context>> context;

--- a/src/context_handle.h
+++ b/src/context_handle.h
@@ -11,6 +11,7 @@ class ContextHandle : public TransferableHandle {
 	friend struct RunRunner;
 	friend struct InstantiateRunner;
 	friend struct EvaluateRunner;
+	friend struct GetModuleNamespaceRunner;
 	friend class NativeModuleHandle;
 	private:
 		std::shared_ptr<RemoteHandle<v8::Context>> context;

--- a/src/isolate_handle.cc
+++ b/src/isolate_handle.cc
@@ -29,14 +29,14 @@ class ScriptOriginHolder {
 		std::string filename;
 		int columnOffset;
 		int lineOffset;
-    bool isModule;
+		bool isModule;
 	public:
-		explicit ScriptOriginHolder(MaybeLocal<Object> maybe_options)
+		explicit ScriptOriginHolder(MaybeLocal<Object> maybe_options, bool is_module = false)
 		  :
 		    filename("<isolated-vm>"),
 		    columnOffset(0),
 		    lineOffset(0),
-		    isModule(false)
+		    isModule(is_module)
     {
 			Local<Object> options;
 			if (maybe_options.ToLocal(&options)) {
@@ -66,23 +66,21 @@ class ScriptOriginHolder {
 			}
 		}
 
-		ScriptOriginHolder & AsModule() {
-		  this->isModule = true;
-		  return *this;
-		}
-
 		ScriptOrigin ToScriptOrigin() {
 			Isolate* isolate = Isolate::GetCurrent();
+			v8::Local<v8::Integer> integer;
+			v8::Local<v8::Boolean> boolean;
+			v8::Local<v8::String> string;
 			return {
-			  v8_string(filename.c_str()),			    // resource_name,
-			  Integer::New(isolate, columnOffset),	// resource_line_offset
-			  Integer::New(isolate, lineOffset),	  // resource_column_offset
-			  Boolean::New(isolate, false),			    // resource_is_shared_cross_origin
-			  Integer::New(isolate, 0),				      // script_id
-			  v8_string(""),						            // source_map_url
-			  Boolean::New(isolate, false),			    // resource_is_opaque
-			  Boolean::New(isolate, false),			    // is_wasm
-			  Boolean::New(isolate, isModule)
+			  v8_string(filename.c_str()),						// resource_name,
+			  Integer::New(isolate, columnOffset),				// resource_line_offset
+			  Integer::New(isolate, lineOffset),				// resource_column_offset
+			  boolean,											// resource_is_shared_cross_origin
+			  integer,											// script_id
+			  string,											// source_map_url
+			  boolean,											// resource_is_opaque
+			  boolean,										    // is_wasm
+			  Boolean::New(isolate, this->isModule)				
             };
 		}
 };
@@ -412,37 +410,41 @@ Local<Value> IsolateHandle::CompileScript(Local<String> code_handle, MaybeLocal<
 */
 struct CompileModuleRunner : public ThreePhaseTask {
 	
-	shared_ptr<IsolateHolder> isolate;
+	shared_ptr<IsolateHolder> isolate_holder;
 	unique_ptr<ExternalCopyString> code_string;
 	unique_ptr<ScriptOriginHolder> script_origin_holder;
-	shared_ptr<RemoteHandle<Module>> module_handle;
+	shared_ptr<IsolatedModule> isolated_module;
 
 	CompileModuleRunner(
-		shared_ptr<IsolateHolder> isolate,
+		shared_ptr<IsolateHolder> isolate_holder,
 		const Local<String>& code_handle,
-		const MaybeLocal<Object>& maybe_options) : isolate(std::move(isolate))
+		const MaybeLocal<Object>& maybe_options) : isolate_holder(std::move(isolate_holder))
 	{
 		// Read options
-		Local<Context> context = Isolate::GetCurrent()->GetCurrentContext(); // is this needed?
-		script_origin_holder = std::make_unique<ScriptOriginHolder>(maybe_options);
+		script_origin_holder = std::make_unique<ScriptOriginHolder>(maybe_options, true);
 		code_string = std::make_unique<ExternalCopyString>(code_handle);
 	}
 
 	void Phase2() final {
-		// Compile in second isolate and return UnboundScript persistent
 		auto isolate = IsolateEnvironment::GetCurrent();
 		Context::Scope context_scope(isolate->DefaultContext());
 		Local<String> code_inner = code_string->CopyIntoCheckHeap().As<String>();
-		ScriptOrigin script_origin = script_origin_holder->AsModule().ToScriptOrigin();
+		ScriptOrigin script_origin = script_origin_holder->ToScriptOrigin();
 		ScriptCompiler::Source source(code_inner, script_origin);
-		module_handle = std::make_shared<RemoteHandle<Module>>(RunWithAnnotatedErrors<Local<Module>>(
-			[&isolate, &source]() { return Unmaybe(ScriptCompiler::CompileModule(*isolate, &source)); }
-		));
+		std::shared_ptr<RemoteHandle<Module>> remote_handle = std::make_shared<RemoteHandle<Module>>(RunWithAnnotatedErrors<Local<Module>>([&]() { return Unmaybe(ScriptCompiler::CompileModule(*isolate, &source)); }));
+		// grab all dependency specifiers
+		size_t dependencySpecifiersLength = remote_handle->Deref()->GetModuleRequestsLength();
+		std::vector<std::string> dependencySpecifiers(dependencySpecifiersLength);
+		for (size_t index = 0; index < dependencySpecifiersLength; ++index) {
+			std::string dependencySpecifier = *Utf8ValueWrapper(*isolate, remote_handle->Deref()->GetModuleRequest(index));
+			dependencySpecifiers[index] = dependencySpecifier;
+		}
+		isolated_module = std::make_shared<IsolatedModule>(isolate_holder, remote_handle, dependencySpecifiers);
 	}
 
 	Local<Value> Phase3() final {
 		// Wrap Module in JS Module{} class
-		Local<Object> value = ClassHandle::NewInstance<ModuleHandle>(std::move(isolate), std::move(module_handle));
+		Local<Object> value = ClassHandle::NewInstance<ModuleHandle>(std::move(isolate_holder), std::move(isolated_module));
 		return value;
 	}
 };

--- a/src/isolate_handle.cc
+++ b/src/isolate_handle.cc
@@ -426,6 +426,7 @@ struct CompileModuleRunner : public ThreePhaseTask {
 	}
 
 	void Phase2() final {
+#if V8_AT_LEAST(6, 1, 328)
 		auto isolate = IsolateEnvironment::GetCurrent();
 		Context::Scope context_scope(isolate->DefaultContext());
 		Local<String> code_inner = code_string->CopyIntoCheckHeap().As<String>();
@@ -442,6 +443,9 @@ struct CompileModuleRunner : public ThreePhaseTask {
 			dependencySpecifiers[index] = dependencySpecifier;
 		}
 		isolated_module = std::make_shared<IsolatedModule>(isolate_holder, remote_handle, dependencySpecifiers);
+#else
+          throw js_generic_error("No module support. At least v8 version 6.1.328 is required");
+#endif
 	}
 
 	Local<Value> Phase3() final {

--- a/src/isolate_handle.cc
+++ b/src/isolate_handle.cc
@@ -439,7 +439,8 @@ struct CompileModuleRunner : public ThreePhaseTask {
 			std::string dependencySpecifier = *Utf8ValueWrapper(*isolate, remote_handle->Deref()->GetModuleRequest(index));
 			dependencySpecifiers[index] = dependencySpecifier;
 		}
-		isolated_module = std::make_shared<IsolatedModule>(isolate_holder, remote_handle, dependencySpecifiers);
+		isolated_module = std::shared_ptr<IsolatedModule>(new IsolatedModule(isolate_holder, remote_handle, dependencySpecifiers), IsolatedModule::shared::remove);
+		IsolatedModule::shared::add(isolated_module.get());
 	}
 
 	Local<Value> Phase3() final {

--- a/src/isolate_handle.h
+++ b/src/isolate_handle.h
@@ -28,6 +28,7 @@ class IsolateHandle : public TransferableHandle {
 
 		template <int async> v8::Local<v8::Value> CreateContext(v8::MaybeLocal<v8::Object> maybe_options);
 		template <int async> v8::Local<v8::Value> CompileScript(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options);
+		template <int async> v8::Local<v8::Value> CompileModule(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options);
 		v8::Local<v8::Value> CreateInspectorSession();
 		v8::Local<v8::Value> Dispose();
 		template <int async> v8::Local<v8::Value> GetHeapStatistics();

--- a/src/isolate_handle.h
+++ b/src/isolate_handle.h
@@ -29,6 +29,7 @@ class IsolateHandle : public TransferableHandle {
 		template <int async> v8::Local<v8::Value> CreateContext(v8::MaybeLocal<v8::Object> maybe_options);
 		template <int async> v8::Local<v8::Value> CompileScript(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options);
 		template <int async> v8::Local<v8::Value> CompileModule(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options);
+		
 		v8::Local<v8::Value> CreateInspectorSession();
 		v8::Local<v8::Value> Dispose();
 		template <int async> v8::Local<v8::Value> GetHeapStatistics();

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -116,7 +116,7 @@ struct InstantiateRunner : public ThreePhaseTask {
 	
 	
 	InstantiateRunner(IsolateHolder* isolate, ContextHandle* context_handle, std::shared_ptr<RemoteHandle<v8::Module>> myModule, std::shared_ptr<ModuleHandle::dependency_map_type> deps)
-		: context(context_handle->context), _module(std::move(myModule)), lock_guard(InstantiateRunnerMutex)Deref
+		: context(context_handle->context), _module(std::move(myModule)), lock_guard(InstantiateRunnerMutex)
 	{
 		// Sanity check
 		context_handle->CheckDisposed();
@@ -143,7 +143,7 @@ struct InstantiateRunner : public ThreePhaseTask {
 
 	void Phase2() final {
 		v8::Isolate* isolate = v8::Isolate::GetCurrent();
-		v8::Maybe<bool> maybe = this->_module->Deref()->InstantiateModule(this->context->Deref(), this->ResolveCallback);
+		v8::Maybe<bool> maybe = this->_module->Deref()->InstantiateModule(this->context->Deref(), InstantiateRunner::ResolveCallback);
 		result = ExternalCopy::CopyIfPrimitive(v8::Boolean::New(isolate, maybe.FromMaybe(false)));
 	}
 

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -82,7 +82,7 @@ void IsolatedModule::SetDependency(const std::string & specifier, std::shared_pt
 	std::lock_guard<IsolatedModule> lock(*this);
 	if (std::find(GetDependencySpecifiers().begin(), GetDependencySpecifiers().end(), specifier) == GetDependencySpecifiers().end()) {
 	  const std::string errorMessage = "Module has no dependency named: \"" + specifier + "\".";
-	  throw js_generic_error(errorMessage.c_str());
+	  throw js_generic_error(errorMessage);
 	}
 	resolutions[specifier] = std::move(isolated_module);
 }

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -1,0 +1,61 @@
+#include "module_handle.h"
+#include "context_handle.h"
+#include "external_copy.h"
+#include "isolate/run_with_timeout.h"
+#include "isolate/three_phase_task.h"
+
+using namespace v8;
+using std::shared_ptr;
+
+namespace ivm {
+
+ModuleHandle::ModuleHandleTransferable::ModuleHandleTransferable(shared_ptr<IsolateHolder> isolate, shared_ptr<RemoteHandle<Module>> myModule)
+	: isolate(std::move(isolate)), _module(std::move(myModule))
+{
+}
+
+Local<Value> ModuleHandle::ModuleHandleTransferable::TransferIn() {
+	return ClassHandle::NewInstance<ModuleHandle>(isolate, _module);
+};
+
+ModuleHandle::ModuleHandle(shared_ptr<IsolateHolder> isolate, shared_ptr<RemoteHandle<Module>> myModule)
+	: isolate(std::move(isolate)), _module(std::move(myModule))
+{
+}
+
+Local<FunctionTemplate> ModuleHandle::Definition() {
+	return Inherit<TransferableHandle>(MakeClass(
+		"Module", nullptr,
+		"release", Parameterize<decltype(&ModuleHandle::Release), &ModuleHandle::Release>(),
+		"link", Parameterize<decltype(&ModuleHandle::Link), &ModuleHandle::Link>(),
+		"instantiate", Parameterize<decltype(&ModuleHandle::Instantiate), &ModuleHandle::Instantiate>(),
+		"evaluate", Parameterize<decltype(&ModuleHandle::Evaluate), &ModuleHandle::Evaluate>()
+	));
+}
+
+std::unique_ptr<Transferable> ModuleHandle::TransferOut() {
+	return std::make_unique<ModuleHandleTransferable>(isolate, _module);
+}
+
+Local<Value> ModuleHandle::Release() {
+	_module.reset();
+	return Undefined(Isolate::GetCurrent());
+}
+
+
+//template <int async>
+Local<Value> ModuleHandle::Link(Local<Function> linker) {
+	throw js_generic_error("Not yet implemented");
+}
+
+
+Local<Value> ModuleHandle::Instantiate() {
+	throw js_generic_error("Not yet implemented");
+}
+
+//template <int async>
+Local<Value> ModuleHandle::Evaluate(v8::MaybeLocal<v8::Object> options) {
+	throw js_generic_error("Not yet implemented");
+}
+
+} // namespace ivm

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -120,7 +120,7 @@ void IsolatedModule::Instantiate(std::shared_ptr<RemoteHandle<v8::Context>> _con
 	context_handle = std::move(_context_handle);
 	Local<Context> context = context_handle->Deref();
 	Local<Module> mod = module_handle->Deref();
-	Unmaybe(mod->InstantiateModule(context, IsolatedModule::ResolveCallback)); // Assume the Unmaybe will throw an exception if InstantiateModule returns false
+	Unmaybe(mod->InstantiateModule(context, IsolatedModule::ResolveCallback));
 }
 
 std::unique_ptr<Transferable> IsolatedModule::Evaluate(std::size_t timeout) {
@@ -172,10 +172,6 @@ Local<FunctionTemplate> ModuleHandle::Definition() {
 		"evaluate", Parameterize<decltype(&ModuleHandle::Evaluate<1>), &ModuleHandle::Evaluate<1>>(),
 		"evaluateSync", Parameterize<decltype(&ModuleHandle::Evaluate<0>), &ModuleHandle::Evaluate<0>>(),
 		"namespace", ParameterizeAccessor<decltype(&ModuleHandle::GetNamespace), &ModuleHandle::GetNamespace>()
-		//"getModuleNamespace", Parameterize<decltype(&ModuleHandle::GetModuleNamespace<1>), &ModuleHandle::GetModuleNamespace<1>>(),
-		//"getModuleNamespaceSync", Parameterize<decltype(&ModuleHandle::GetModuleNamespace<0>), &ModuleHandle::GetModuleNamespace<0>>()
-		/*"release", Parameterize<decltype(&ModuleHandle::Release), &ModuleHandle::Release>(),
-		*/
 	));
 }
 
@@ -198,8 +194,8 @@ Local<Value> ModuleHandle::GetDependencySpecifiers() {
 }
 
 
-Local<Value> ModuleHandle::SetDependency(Local<String> value, ModuleHandle* module_handle) {
-	std::string dependency = *Utf8ValueWrapper(Isolate::GetCurrent(), value);
+Local<Value> ModuleHandle::SetDependency(Local<String> specifier, ModuleHandle* module_handle) {
+	std::string dependency = *Utf8ValueWrapper(Isolate::GetCurrent(), specifier);
 	isolated_module->SetDependency(dependency, module_handle->isolated_module);
 	return Undefined(Isolate::GetCurrent());
 }

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -26,6 +26,9 @@ ModuleHandle::ModuleHandle(shared_ptr<IsolateHolder> isolate, shared_ptr<RemoteH
 Local<FunctionTemplate> ModuleHandle::Definition() {
 	return Inherit<TransferableHandle>(MakeClass(
 		"Module", nullptr,
+		"getModuleRequestsLength", Parameterize<decltype(&ModuleHandle::GetModuleRequestsLength), &ModuleHandle::GetModuleRequestsLength>(),
+		"getModuleRequest", Parameterize<decltype(&ModuleHandle::GetModuleRequest<1>), &ModuleHandle::GetModuleRequest<1>>(),
+		"getModuleRequestSync", Parameterize<decltype(&ModuleHandle::GetModuleRequest<0>), &ModuleHandle::GetModuleRequest<0>>(),
 		"release", Parameterize<decltype(&ModuleHandle::Release), &ModuleHandle::Release>(),
 		"link", Parameterize<decltype(&ModuleHandle::Link), &ModuleHandle::Link>(),
 		"instantiate", Parameterize<decltype(&ModuleHandle::Instantiate), &ModuleHandle::Instantiate>(),
@@ -37,9 +40,44 @@ std::unique_ptr<Transferable> ModuleHandle::TransferOut() {
 	return std::make_unique<ModuleHandleTransferable>(isolate, _module);
 }
 
-Local<Value> ModuleHandle::Release() {
-	_module.reset();
-	return Undefined(Isolate::GetCurrent());
+
+
+struct GetModuleRequestRunner : public ThreePhaseTask {
+	std::unique_ptr<Transferable> result;
+	std::shared_ptr<RemoteHandle<v8::Module>> _module;
+  std::size_t _index;
+
+	GetModuleRequestRunner(std::shared_ptr<RemoteHandle<v8::Module>> myModule, std::size_t index)
+	  : _module(std::move(myModule)), _index(index)
+  {
+	}
+
+	void Phase2() final {
+		auto request = this->_module->Deref()->GetModuleRequest(this->_index);
+		result = ExternalCopy::CopyIfPrimitive(request);
+	}
+
+	Local<Value> Phase3() final {
+		if (result) {
+			return result->TransferIn();
+		} else {
+			return v8::Undefined(v8::Isolate::GetCurrent()).As<v8::Value>();
+		}
+	}
+
+};
+
+
+
+v8::Local<v8::Value> ModuleHandle::GetModuleRequestsLength() {
+  const std::size_t length = this->_module->Deref()->GetModuleRequestsLength();
+  Isolate* isolate = Isolate::GetCurrent();
+  return v8::Integer::New(isolate, length);
+}
+
+template <int async>
+v8::Local<v8::Value> ModuleHandle::GetModuleRequest(v8::Local<v8::Value> index) {
+	return ThreePhaseTask::Run<async, GetModuleRequestRunner>(*this->isolate, this->_module, index->Int32Value());
 }
 
 
@@ -56,6 +94,11 @@ Local<Value> ModuleHandle::Instantiate() {
 //template <int async>
 Local<Value> ModuleHandle::Evaluate(v8::MaybeLocal<v8::Object> options) {
 	throw js_generic_error("Not yet implemented");
+}
+
+Local<Value> ModuleHandle::Release() {
+	_module.reset();
+	return Undefined(Isolate::GetCurrent());
 }
 
 } // namespace ivm

--- a/src/module_handle.cc
+++ b/src/module_handle.cc
@@ -77,7 +77,7 @@ const std::vector<std::string> & IsolatedModule::GetDependencySpecifiers() const
 	return dependency_specifiers;
 }
 
-void IsolatedModule::SetDependency(std::string specifier, std::shared_ptr<IsolatedModule> isolated_module) {
+void IsolatedModule::SetDependency(const std::string & specifier, std::shared_ptr<IsolatedModule> isolated_module) {
 	// Probably not a good idea because if dynamic import() anytime get supported()
 	std::lock_guard<IsolatedModule> lock(*this);
 	if (std::find(GetDependencySpecifiers().begin(), GetDependencySpecifiers().end(), specifier) == GetDependencySpecifiers().end()) {

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -35,7 +35,7 @@ private:
 	// helper methods
 	static v8::MaybeLocal<v8::Module> ResolveCallback(v8::Local<v8::Context>, v8::Local<v8::String>, v8::Local<v8::Module>); // we may be able to use a weak map so can the ResolveCallback use the referrer value
 public:
-	IsolatedModule(std::shared_ptr<IsolateHolder>, std::shared_ptr<RemoteHandle<v8::Module>>, std::vector<std::string>);
+    IsolatedModule(std::shared_ptr<IsolateHolder> isolate, std::shared_ptr<RemoteHandle<v8::Module>> handle, std::vector<std::string> dependency_specifiers);
 	~IsolatedModule();
 	
 	// BasicLockable requirements

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -41,6 +41,9 @@ class ModuleHandle : public TransferableHandle {
 		template <int async>
 		v8::Local<v8::Value> Evaluate(ContextHandle*, v8::MaybeLocal<v8::Object>);
 
+		template <int async>
+		v8::Local<v8::Value> GetModuleNamespace(ContextHandle*);
+
 		v8::Local<v8::Value> Release();
 };
 

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -35,10 +35,8 @@ class ModuleHandle : public TransferableHandle {
 		v8::Local<v8::Value> GetModuleRequest(v8::Local<v8::Value>);
 
 
-		//template <int async>
-		v8::Local<v8::Value> Link(v8::Local<v8::Function>);
-
-		v8::Local<v8::Value> Instantiate();
+		template <int async>
+		v8::Local<v8::Value> Instantiate(ContextHandle*, v8::MaybeLocal<v8::Object>);	
 
 		//template <int async>
 		v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <v8.h>
+#include "isolate/holder.h"
+#include "isolate/remote_handle.h"
+#include "transferable_handle.h"
+#include <memory>
+
+namespace ivm {
+
+class ContextHandle;
+
+class ModuleHandle : public TransferableHandle {
+	private:
+		class ModuleHandleTransferable : public Transferable {
+			private:
+				std::shared_ptr<IsolateHolder> isolate;
+				std::shared_ptr<RemoteHandle<v8::Module>> _module;
+			public:
+				ModuleHandleTransferable(std::shared_ptr<IsolateHolder>, std::shared_ptr<RemoteHandle<v8::Module>>);
+				v8::Local<v8::Value> TransferIn() final;
+		};
+
+		std::shared_ptr<IsolateHolder> isolate;
+		std::shared_ptr<RemoteHandle<v8::Module>> _module;
+
+	public:
+		ModuleHandle(std::shared_ptr<IsolateHolder>,std::shared_ptr<RemoteHandle<v8::Module>>);
+
+		static v8::Local<v8::FunctionTemplate> Definition();
+		std::unique_ptr<Transferable> TransferOut() final;
+
+		//template <int async>
+		v8::Local<v8::Value> Link(v8::Local<v8::Function>);
+
+		v8::Local<v8::Value> Instantiate();
+
+		//template <int async>
+    v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);
+
+		v8::Local<v8::Value> Release();
+};
+
+} // namespace ivm

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -4,18 +4,18 @@
 #include "isolate/remote_handle.h"
 #include "transferable_handle.h"
 #include <memory>
-#include <unordered_map>
+#include <unordered_set>
 
 namespace ivm {
 
 
-class IsolatedModule /*: public std::enable_shared_from_this<IsolatedModule>*/  { // we need this to access the parent shared_ptr
+class IsolatedModule : public std::enable_shared_from_this<IsolatedModule>  { // we need this to access the parent shared_ptr
 private:
 	struct shared {
-		// keeps track of the information ResolveCallback need to dynamically resolve a module
-		// the information is also probably required by SetHostImportModuleDynamicallyCallback - if added
+		// My idea is we could some how store information here so all modules could be resolved using only this information.
+		// in that case may it be simple to support dynamic  import() too
 		static std::mutex mutex;
-		s//tatic std::unordered_map<std::weak_ptr<IsolatedModule>, std::shared_ptr<IsolatedModule>> resolutions;
+		static std::unordered_set<IsolatedModule> available_modules;
 	};
 
 	std::mutex mutex;

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -4,12 +4,15 @@
 #include "isolate/remote_handle.h"
 #include "transferable_handle.h"
 #include <memory>
+#include <map>
 
 namespace ivm {
 
 class ContextHandle;
 
 class ModuleHandle : public TransferableHandle {
+	public:
+	typedef std::map<std::string, std::shared_ptr<RemoteHandle<v8::Module>>> dependency_map_type;
 	private:
 		class ModuleHandleTransferable : public Transferable {
 			private:
@@ -22,7 +25,7 @@ class ModuleHandle : public TransferableHandle {
 
 		std::shared_ptr<IsolateHolder> isolate;
 		std::shared_ptr<RemoteHandle<v8::Module>> _module;
-
+		std::shared_ptr<dependency_map_type> dependencies;
 	public:
 		ModuleHandle(std::shared_ptr<IsolateHolder>,std::shared_ptr<RemoteHandle<v8::Module>>);
 
@@ -34,9 +37,10 @@ class ModuleHandle : public TransferableHandle {
 		template <int async>
 		v8::Local<v8::Value> GetModuleRequest(v8::Local<v8::Value>);
 
+		v8::Local<v8::Value> SetDependency(v8::Local<v8::Value>, ModuleHandle*);
 
 		template <int async>
-		v8::Local<v8::Value> Instantiate(ContextHandle*, v8::MaybeLocal<v8::Object>);	
+		v8::Local<v8::Value> Instantiate(ContextHandle*);	
 
 		template <int async>
 		v8::Local<v8::Value> Evaluate(ContextHandle*, v8::MaybeLocal<v8::Object>);

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -44,7 +44,7 @@ public:
 
 	const std::vector<std::string> & GetDependencySpecifiers() const;
 
-	void SetDependency(std::string, std::shared_ptr<IsolatedModule>);
+	void SetDependency(const std::string &, std::shared_ptr<IsolatedModule>);
 	
 	void Instantiate(std::shared_ptr<RemoteHandle<v8::Context>>);
 

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -29,13 +29,19 @@ class ModuleHandle : public TransferableHandle {
 		static v8::Local<v8::FunctionTemplate> Definition();
 		std::unique_ptr<Transferable> TransferOut() final;
 
+		v8::Local<v8::Value> GetModuleRequestsLength();
+
+		template <int async>
+		v8::Local<v8::Value> GetModuleRequest(v8::Local<v8::Value>);
+
+
 		//template <int async>
 		v8::Local<v8::Value> Link(v8::Local<v8::Function>);
 
 		v8::Local<v8::Value> Instantiate();
 
 		//template <int async>
-    v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);
+		v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);
 
 		v8::Local<v8::Value> Release();
 };

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -38,8 +38,8 @@ class ModuleHandle : public TransferableHandle {
 		template <int async>
 		v8::Local<v8::Value> Instantiate(ContextHandle*, v8::MaybeLocal<v8::Object>);	
 
-		//template <int async>
-		v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);
+		template <int async>
+		v8::Local<v8::Value> Evaluate(ContextHandle*, v8::MaybeLocal<v8::Object>);
 
 		v8::Local<v8::Value> Release();
 };

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -1,64 +1,97 @@
 #pragma once
 #include <v8.h>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 #include "isolate/holder.h"
 #include "isolate/remote_handle.h"
 #include "transferable_handle.h"
-#include <memory>
-#include <unordered_map>
-#include <mutex>
 
 namespace ivm {
 
-
 class IsolatedModule {
-public:
-	class shared {
-	private:
-		using available_modules_type = std::unordered_multimap<int, IsolatedModule*>;
-		static std::mutex mutex;
-		static available_modules_type available_modules;
-	public:
-		// using raw pointers locks dangerous maybe, but couldn´t get it to work with weak_ptr.
-		static IsolatedModule* find(v8::Local<v8::Module>);
-		static void add(IsolatedModule*);
-		static void remove(IsolatedModule*);
-	};
-private:
-	std::recursive_mutex mutex;
-	std::shared_ptr<IsolateHolder> isolate; // required by ClassHandle used to construct the namespace reference
-	std::vector<std::string> dependency_specifiers;
-	std::shared_ptr<RemoteHandle<v8::Module>> module_handle;
-	std::shared_ptr<RemoteHandle<v8::Context>> context_handle;
-	std::shared_ptr<RemoteHandle<v8::Value>> global_namespace;
-	std::unordered_map<std::string, std::shared_ptr<IsolatedModule>> resolutions;
-private:
-	// helper methods
-	static v8::MaybeLocal<v8::Module> ResolveCallback(v8::Local<v8::Context>, v8::Local<v8::String>, v8::Local<v8::Module>); // we may be able to use a weak map so can the ResolveCallback use the referrer value
-public:
-    IsolatedModule(std::shared_ptr<IsolateHolder> isolate, std::shared_ptr<RemoteHandle<v8::Module>> handle, std::vector<std::string> dependency_specifiers);
-	~IsolatedModule();
+ public:
+#if V8_AT_LEAST(6, 1, 328)
+  class shared {
+   private:
+    using available_modules_type =
+        std::unordered_multimap<int, IsolatedModule*>;
+    static std::mutex mutex;
+    static available_modules_type available_modules;
+
+   public:
+    // using raw pointers locks dangerous maybe, but couldn´t get it to work
+    // with weak_ptr.
+    static IsolatedModule* find(v8::Local<v8::Module> handle);
+    static void add(IsolatedModule* ptr);
+    static void remove(IsolatedModule* ptr);
+  };
+
+ private:
+  std::recursive_mutex mutex;
+  std::shared_ptr<IsolateHolder> isolate;  // required by ClassHandle used to
+                                           // construct the namespace reference
+  std::vector<std::string> dependency_specifiers;
+  std::shared_ptr<RemoteHandle<v8::Module>> module_handle;
+  std::shared_ptr<RemoteHandle<v8::Context>> context_handle;
+  std::shared_ptr<RemoteHandle<v8::Value>> global_namespace;
+  std::unordered_map<std::string, std::shared_ptr<IsolatedModule>> resolutions;
+
+ private:
+  // helper methods
+  static v8::MaybeLocal<v8::Module> ResolveCallback(
+      v8::Local<v8::Context> context, v8::Local<v8::String> specifier,
+      v8::Local<v8::Module> referrer);
+
+ public:
+  IsolatedModule(std::shared_ptr<IsolateHolder> isolate,
+                 std::shared_ptr<RemoteHandle<v8::Module>> handle,
+                 std::vector<std::string> dependency_specifiers);
+  ~IsolatedModule();
+
+  // BasicLockable requirements
+  void lock();
+  void unlock();
+
+  const std::vector<std::string>& GetDependencySpecifiers() const;
+
+  void SetDependency(const std::string& specifier,
+                     std::shared_ptr<IsolatedModule> isolated_module);
+
+  void Instantiate(std::shared_ptr<RemoteHandle<v8::Context>> _context_handle);
+
+  std::unique_ptr<Transferable> Evaluate(std::size_t timeout);
+
+  v8::Local<v8::Value> GetNamespace();
+
+  friend bool operator==(const IsolatedModule&, const v8::Local<v8::Module>&);
+#else
+	inline void lock() {}
+	inline void unlock() {};
+
+	inline const std::vector<std::string> & GetDependencySpecifiers() const {
+		throw js_generic_error("OPERATION NOT SUPPORTED");
+	}
+
+	inline void SetDependency(const std::string & specifier, std::shared_ptr<IsolatedModule> isolated_module) {
+	}
 	
-	// BasicLockable requirements
-	void lock();
-	void unlock();
+	inline void Instantiate(std::shared_ptr<RemoteHandle<v8::Context>> _context_handle) {
 
-	const std::vector<std::string> & GetDependencySpecifiers() const;
+	}
 
-	void SetDependency(const std::string &, std::shared_ptr<IsolatedModule>);
-	
-	void Instantiate(std::shared_ptr<RemoteHandle<v8::Context>>);
+	std::unique_ptr<Transferable> Evaluate(std::size_t timeout) {
+		throw js_generic_error("OPERATION NOT SUPPORTED");
+	}
 
-	std::unique_ptr<Transferable> Evaluate(std::size_t);
-
-	v8::Local<v8::Value> GetNamespace();
-
-	friend bool operator==(const IsolatedModule&, const v8::Local<v8::Module>&);
+	v8::Local<v8::Value> GetNamespace() {
+		throw js_generic_error("OPERATION NOT SUPPORTED");
+	}
+#endif
 };
 
 class ContextHandle;
 class ModuleHandle : public TransferableHandle {
-	public:
-	//typedef std::map<std::string, std::shared_ptr<RemoteHandle<v8::Module>>> dependency_map_type;
 	private:
 		class ModuleHandleTransferable : public Transferable {
 			private:
@@ -72,28 +105,23 @@ class ModuleHandle : public TransferableHandle {
 		std::shared_ptr<IsolateHolder> isolate;
 		std::shared_ptr<IsolatedModule> isolated_module; 
 	public:
-		ModuleHandle(std::shared_ptr<IsolateHolder>, std::shared_ptr<IsolatedModule>);
+		ModuleHandle(std::shared_ptr<IsolateHolder> isolate, std::shared_ptr<IsolatedModule> isolated_module);
 
 		static v8::Local<v8::FunctionTemplate> Definition();
 		std::unique_ptr<Transferable> TransferOut() final;
 
 		v8::Local<v8::Value> GetDependencySpecifiers();
 		
-		v8::Local<v8::Value> SetDependency(v8::Local<v8::String>, ModuleHandle*);
+		v8::Local<v8::Value> SetDependency(v8::Local<v8::String> specifier, ModuleHandle* module_handle);
 		
 		template <int async>
-		v8::Local<v8::Value> Instantiate(ContextHandle*);	
+        v8::Local<v8::Value> Instantiate(ContextHandle* context_handle);	
 
 		
 		template <int async>
-		v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object>);
+		v8::Local<v8::Value> Evaluate(v8::MaybeLocal<v8::Object> maybe_options);
 
 		v8::Local<v8::Value> GetNamespace();
-		/*
-		template <int async>
-		v8::Local<v8::Value> GetModuleNamespace(ContextHandle*);
-
-		v8::Local<v8::Value> Release();*/
 };
 
 } // namespace ivm

--- a/src/module_handle.h
+++ b/src/module_handle.h
@@ -10,11 +10,11 @@
 namespace ivm {
 
 
-class IsolatedModule : public std::enable_shared_from_this<IsolatedModule> {
+class IsolatedModule {
 public:
 	class shared {
 	private:
-		typedef std::unordered_multimap<int, IsolatedModule*> available_modules_type; // managed by a shared_ptr::deleter in compileModule::phase2
+		using available_modules_type = std::unordered_multimap<int, IsolatedModule*>;
 		static std::mutex mutex;
 		static available_modules_type available_modules;
 	public:
@@ -26,7 +26,7 @@ public:
 private:
 	std::recursive_mutex mutex;
 	std::shared_ptr<IsolateHolder> isolate; // required by ClassHandle used to construct the namespace reference
-	std::vector<std::string> dependencySpecifiers;
+	std::vector<std::string> dependency_specifiers;
 	std::shared_ptr<RemoteHandle<v8::Module>> module_handle;
 	std::shared_ptr<RemoteHandle<v8::Context>> context_handle;
 	std::shared_ptr<RemoteHandle<v8::Value>> global_namespace;
@@ -36,6 +36,7 @@ private:
 	static v8::MaybeLocal<v8::Module> ResolveCallback(v8::Local<v8::Context>, v8::Local<v8::String>, v8::Local<v8::Module>); // we may be able to use a weak map so can the ResolveCallback use the referrer value
 public:
 	IsolatedModule(std::shared_ptr<IsolateHolder>, std::shared_ptr<RemoteHandle<v8::Module>>, std::vector<std::string>);
+	~IsolatedModule();
 	
 	// BasicLockable requirements
 	void lock();

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -30,6 +30,12 @@ const { strictEqual, throws } = require('assert');
     const result = defaultExport.applySync(null, [ 2, 4 ]);
     strictEqual(result, 6);
   }
+  function setupModuleNamespaceAndRunChecks() {
+    const data = (moduleMap.namespace = {});
+    const code = `export default function add(a, b) { return a + b; };`;
+    const module = data.module = isolate.compileModuleSync(code);
+    throws(() => module.namespace);
+  }
 
   function setupModuleInstantiateErrorAndRunChecks() {
     const data = (moduleMap.instantiateError = {});
@@ -112,6 +118,7 @@ const { strictEqual, throws } = require('assert');
   }
   try {
     setupModuleAddAndRunChecks();
+    setupModuleNamespaceAndRunChecks();
     setupModuleInstantiateErrorAndRunChecks();
     setupModuleTimeoutAndRunChecks();
     setupModuleEvaluateErrorAndRunChecks();

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -1,0 +1,20 @@
+/**
+ * Checks if object returned by the isolate.compileModuleSync() returns an object that statisfy nodejs vm.Module class
+ **/
+const ivm = require('isolated-vm');
+const { strictEqual } = require('assert');
+
+(function () {
+  const isolate = new ivm.Isolate();
+  const code = `export default function add(a, b) { return a + b; }`;
+  try {
+    const module = isolate.compileModuleSync(code);
+    strictEqual(typeof module.link, 'function');
+    strictEqual(typeof module.instantiate, 'function');
+    strictEqual(typeof module.evaluate, 'function');
+    console.log('pass');
+  } catch(err) {
+    console.log(err);
+  }
+
+})();

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -6,10 +6,18 @@ const { strictEqual } = require('assert');
 
 (function () {
   const isolate = new ivm.Isolate();
-  const code = `export default function add(a, b) { return a + b; }`;
+  const code = `
+    import first from './first';
+    import second from './second';
+    export default function add(a, b) { return a + b; }
+  `;
   try {
     const module = isolate.compileModuleSync(code);
-    strictEqual(typeof module.link, 'function');
+    strictEqual(typeof module.getModuleRequestsLength, 'function');
+    const moduleRequestsLength = module.getModuleRequestsLength();
+    strictEqual(moduleRequestsLength, 2);
+    const moduleRequests = Array.from({ length: moduleRequestsLength }).map((val, index) => module.getModuleRequestSync(index));
+    strictEqual(JSON.stringify(moduleRequests), JSON.stringify(['./first', './second']))
     strictEqual(typeof module.instantiate, 'function');
     strictEqual(typeof module.evaluate, 'function');
     console.log('pass');

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -2,7 +2,7 @@
  * Checks if object returned by the isolate.compileModuleSync() returns an object that statisfy nodejs vm.Module class
  **/
 const ivm = require('isolated-vm');
-const { strictEqual } = require('assert');
+const { strictEqual, throws } = require('assert');
 
 (function () {
   const isolate = new ivm.Isolate();
@@ -12,18 +12,31 @@ const { strictEqual } = require('assert');
 
   function setupModuleAddAndRunChecks() {
     const data = (moduleMap.add = {});
-    const code = `export default function add(a, b) { return a + b; }`;
+    const code = `export default function add(a, b) { return a + b; };"This is awesome!";`;
     const module = data.module = isolate.compileModuleSync(code);
     strictEqual(typeof module.getModuleRequestsLength, 'function');
     const moduleRequestsLength = module.getModuleRequestsLength();
     strictEqual(moduleRequestsLength, 0);
     strictEqual(typeof module.instantiateSync, 'function');
-    const success = module.instantiateSync(context);
-    strictEqual(success, true);
+    const instantiateResult = module.instantiateSync(context);
+    strictEqual(instantiateResult, true);
+    strictEqual(typeof module.evaluateSync, 'function');
+    const evaluateResult = module.evaluateSync(context);
+    strictEqual('This is awesome!', evaluateResult);
+  }
+
+  function setupModuleTimeoutAndRunChecks() {
+    const data = (moduleMap.timeout = {});
+    const code = `let i = 0; while(++i); i;`; // should generate a timeout
+    const module = data.module = isolate.compileModuleSync(code);
+    const instantiateResult = module.instantiateSync(context);
+    strictEqual(instantiateResult, true);
+    throws(() => module.evaluateSync(context, { timeout: 50 }));
   }
 
   try {
     setupModuleAddAndRunChecks();
+    setupModuleTimeoutAndRunChecks();
     console.log('pass');
   } catch(err) {
     console.log(err);

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -1,5 +1,5 @@
 /**
- * Checks if object returned by the isolate.compileModuleSync() returns an object that statisfy nodejs vm.Module class
+ * Checks if it is possible to create es6 modules.
  **/
 const ivm = require('isolated-vm');
 const { strictEqual, throws } = require('assert');
@@ -42,9 +42,56 @@ const { strictEqual, throws } = require('assert');
     throws(() => module.evaluateSync(context, { timeout: 50 }));
   }
 
+  function setupModuleEvaluateErrorAndRunChecks() {
+    const data = (moduleMap.evaluate = {});
+    const code = `throw new Error('Some error');`;
+    const module = data.module = isolate.compileModuleSync(code);
+    const instantiateResult = module.instantiateSync(context);
+    strictEqual(instantiateResult, true);
+    throws(() => module.evaluateSync(context));
+  }
+
+  function setupModuleMathAndRunChecks() {
+    const data = (moduleMap.math = {});
+    const code = `
+      import add from './add';
+      export { add };
+      
+      export function sub(a, b) {
+        return add(a, -b);
+      };
+    `;
+    const module = data.module = isolate.compileModuleSync(code);
+    const moduleRequestsLength = module.getModuleRequestsLength();
+    strictEqual(moduleRequestsLength, 1);
+    const dependencySpecifiers = Array.from({ length: moduleRequestsLength})
+      .map((val, index) => module.getModuleRequestSync(index));
+
+    strictEqual(JSON.stringify(dependencySpecifiers), JSON.stringify(['./add']));
+    strictEqual(typeof module.setDependency, 'function');
+    strictEqual(module.setDependency('./add', moduleMap.add.module), true);
+    const instantiateResult = module.instantiateSync(context);
+    strictEqual(instantiateResult, true);
+
+    // lets try to use add through our "math" library
+    const reference = module.getModuleNamespaceSync(context);
+    strictEqual(reference.typeof, 'object');
+    const add = reference.getSync('add');
+    strictEqual(typeof add, 'object');
+    strictEqual(add.typeof, 'function');
+    strictEqual(add.applySync(null, [ 2, 4 ]), 6);
+
+    const sub = reference.getSync('sub');
+    strictEqual(typeof sub, 'object');
+    strictEqual(sub.typeof, 'function');
+    strictEqual(sub.applySync(null, [ 2, 4 ]), -2);
+  }
+
   try {
     setupModuleAddAndRunChecks();
     setupModuleTimeoutAndRunChecks();
+    setupModuleEvaluateErrorAndRunChecks();
+    setupModuleMathAndRunChecks();
     console.log('pass');
   } catch(err) {
     console.log(err);

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -72,7 +72,7 @@ const { strictEqual, throws } = require('assert');
     strictEqual(module.setDependency('./add', moduleMap.add.module), true);
     const instantiateResult = module.instantiateSync(context);
     strictEqual(instantiateResult, true);
-
+    module.evaluateSync(context);
     // lets try to use add through our "math" library
     const reference = module.getModuleNamespaceSync(context);
     strictEqual(reference.typeof, 'object');

--- a/tests/module-basic.js
+++ b/tests/module-basic.js
@@ -23,6 +23,14 @@ const { strictEqual, throws } = require('assert');
     strictEqual(typeof module.evaluateSync, 'function');
     const evaluateResult = module.evaluateSync(context);
     strictEqual('This is awesome!', evaluateResult);
+
+    const reference = module.getModuleNamespaceSync(context);
+    strictEqual(reference.typeof, 'object');
+    const defaultExport = reference.getSync('default');
+    strictEqual(typeof defaultExport, 'object');
+    strictEqual(defaultExport.typeof, 'function');
+    const result = defaultExport.applySync(null, [ 2, 4 ]);
+    strictEqual(result, 6);
   }
 
   function setupModuleTimeoutAndRunChecks() {


### PR DESCRIPTION
Hi again!
This pull request adds basic support for es6 modules. It is just a thin wrapper above v8::Module. The user must manually query over all dependency specifiers and invoke module.setDependency() just as the proposal. For usage check test: tests/module-basic.js. I have added some documentation in the README.md too.

BUG:
There is currently a bug (see "module.getModuleNamespace"/README.md) and I have no idea how to fix it. But you maybe know?


Let me know what you think! 