### PR TITLE
fix: typings

### DIFF
--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -268,7 +268,7 @@ declare module "isolated-vm" {
 		instantiateSync(
 			context: Context,
 			resolveCallback: (specifier: string, referrer: Module) => Module
-		);
+		): void;
 
 		/**
 		 * Evaluate the module and return the last expression (same as script.run). If evaluate is called more than once on the same module the return value from the first invocation will be returned (or thrown).


### PR DESCRIPTION
`Module#instantiateSync` had no return type specified in the typings. I assume it mirrors the signature of `Module#instantiate` except without the Promise.