### PR TITLE
amazon linux ami c++14 support in gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ too old.
 * Windows + OS X users should follow the instuctions here: [node-gyp](https://github.com/nodejs/node-gyp)
 * Ubuntu users should run: `sudo apt-get install g++ build-essential`
 * Alpine users should run: `sudo apk add python make g++`
-
+* Amazon Linux AMI users should run: `sudo yum install gcc72 gcc72-c++`
 
 WHO IS USING ISOLATED-VM
 ------------------------


### PR DESCRIPTION
fixes g++ 4.8 error: unrecognized command line option ‘-std=c++14’