### PR TITLE
Reinstate minimum for v8 max_semi_space_size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolated-vm",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Access to multiple isolates",
   "main": "isolated-vm.js",
   "types": "isolated-vm.d.ts",

--- a/src/isolate/environment.cc
+++ b/src/isolate/environment.cc
@@ -278,7 +278,7 @@ void IsolateEnvironment::IsolateCtor(size_t memory_limit_in_mb, shared_ptr<void>
 
 	// Calculate resource constraints
 	ResourceConstraints rc;
-	rc.set_max_semi_space_size_in_kb((size_t)std::pow(2, memory_limit_in_mb / 128.0 + 10.0));
+	rc.set_max_semi_space_size_in_kb((size_t)std::pow(2, std::min(sizeof(void*) >= 8 ? 4.0 : 3.0, memory_limit_in_mb / 128.0) + 10));
 	rc.set_max_old_space_size(
 #if V8_AT_LEAST(7, 0, 0)
 		memory_limit_in_mb

--- a/tests/heap-limit-high.js
+++ b/tests/heap-limit-high.js
@@ -1,0 +1,7 @@
+const ivm = require('isolated-vm');
+
+let isolate = new ivm.Isolate({ memoryLimit: 10 * 1024 * 1024 });
+let context = isolate.createContextSync();
+
+isolate.compileScriptSync(``).runSync(context);
+console.log('pass');


### PR DESCRIPTION
v8's `max_semi_space_size` has no minimum in versions of v8 prior to 7.7.25. If the memory limit passed to isolated-vm is large enough,

```c++
std::pow(2, memory_limit_in_mb / 128.0 + 10.0))
```
can overflow a 64-bit integer and result in an extremely low `max_semi_space_size` value, which crashes the process.

This PR reverts the calculation to what it was before 2e4cc0c7e6b2d9bfb9bdd627e6c523e2face91bd:

```c++
std::pow(std::min(sizeof(void*) >= 8 ? 4.0 : 3.0, memory_limit_in_mb / 128.0) + 10)
```
It now includes a maximum value of 16KB or 8KB, depending on address width.

I went back and forth on whether to wrap this in `#if V8_AT_LEAST` but feel that it is better to be explicit and not rely on implicit v8 behavior for handling the error case. Let me know what you think.

I have added a test that reproduces the issue. The following never completes:
```js
const ivm = require('isolated-vm');

let isolate = new ivm.Isolate({ memoryLimit: 10 * 1024 * 1024 });
let context = isolate.createContextSync();

isolate.compileScriptSync(``).runSync(context);
console.log('pass');  // never printed
```

Note that node > v12.10.0 uses v8 7.7.299.11 and does not suffer from this problem.