### PR TITLE
Add Algolia to the list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ for several days at a time.
 just static resources. They are using isolated-vm to run globally distributed applications, where
 each application may have wildly different traffic patterns.
 
+* [Algolia](https://www.algolia.com) - Algolia is a Search as a Service provider. They use
+`isolated-vm` to power their [Custom Crawler](https://www.algolia.com/products/crawler/) product,
+which allows them to safely execute user-provided code for content extraction.
 
 API DOCUMENTATION
 -----------------


### PR DESCRIPTION
We've been using `isolated-vm` at Algolia for our crawler (which I've been a dev on for the entire project life) for the past year and I have to say that it was a blast. It's one of our core security mechanisms.
We spent so much time looking at alternatives, that when we discovered it, it almost felt too good to be true.

By the way, `How to run untrusted JavaScript code` is a banned question on StackOverflow because it has been asked so many times. I've mentioned `isolated-vm` in one of the most popular ones and flagged a lot of them as duplicates.
https://stackoverflow.com/questions/10937870/how-to-run-untrusted-code-serverside

I plan to do a few presentations about our usage of the lib, and would be happy to see our name in your user list. :)