### PR TITLE
Declare isolated-vm module as transferable in TypeScript types

### DIFF
--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -12,7 +12,8 @@ declare module "isolated-vm" {
 		| Copy<any>
 		| Reference<any>
 		| Dereference<any>
-		| Module;
+		| Module
+		| typeof import("isolated-vm");
 
 	/**
 	 * This is the main reference to an isolate. Every handle to an isolate is transferable, which


### PR DESCRIPTION
Very simple change to allow for code such as the following when using TypeScript:

```ts
import ivm from "isolated-vm";

const isolate = new ivm.Isolate();
const context = isolate.createContextSync();

// Previously saw the following error at this line:
// Argument of type 'typeof import("isolated-vm")' is not assignable to parameter of type 'Transferable'.
context.global.setSync("_ivm", ivm);

// ...
```