### PR TITLE
Add static linking

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -87,6 +87,11 @@
 				'src/module/session_handle.cc',
 				'src/module/transferable.cc',
 			],
+			'link_settings': {
+                		'ldflags': [
+                    			'-static-libgcc -static-libstdc++'
+                		]
+            		},
 			'conditions': [
 				[ 'OS != "win"', {
 					'dependencies': [ 'nortti' ],


### PR DESCRIPTION
Not sure if this is preferable by everyone but makes the build portable so it is easier to deploy in some cases.

I usually do this via:
`LDFLAGS='-static-libgcc -static-libstdc++' node-gyp rebuild --release -j 4`

does it achieve the same thing?