### PR TITLE
Fix segfault when throwing Errors with non-string primitive messages

### DIFF
--- a/src/external_copy/external_copy.cc
+++ b/src/external_copy/external_copy.cc
@@ -266,10 +266,12 @@ auto ExternalCopy::CopyThrownValue(Local<Value> value) -> std::unique_ptr<Extern
 				if (value->IsString()) {
 					return ExternalCopyString{value.As<String>()};
 				}
+				Local<String> message_string = Unmaybe(value->ToString(context));
+				return ExternalCopyString{message_string};
 			} catch (const RuntimeError& cc_err) {
 				try_catch.Reset();
 			}
-			return ExternalCopyString{};
+			return ExternalCopyString{v8_string("")};
 		};
 		ExternalCopyString message_copy = get_property(object, "message");
 		ExternalCopyString stack_copy = get_property(object, "stack");


### PR DESCRIPTION
We've stumbled upon a segfault that occurs when an ivm isolate throws an Error which has a non-string message property value.


This patch is enough to stop the crash by simply using the stringified version of the value if it's not already a string, and defaults to a worst-case scenario of an empty string.

Minimal repro:
```ts
const ivm = require("./isolated-vm");

(async () => {
  const isolate = new ivm.Isolate();
  const ctx = await isolate.createContext();

  await ctx.eval(`
    const err = new Error;
    err.message = 1; // any non-string primitive value
    throw err;
  `);
})();
```

Backtrace:
```
Thread 1 "node" received signal SIGSEGV, Segmentation fault.
ivm::ExternalCopyString::CopyInto (this=this@entry=0x7fffe0001968) at ../src/external_copy/string.cc:102
102             if (value->size() < 1024) {
(gdb) bt
#0  ivm::ExternalCopyString::CopyInto (this=this@entry=0x7fffe0001968) at ../src/external_copy/string.cc:102
#1  0x00007ffff41e44c1 in ivm::ExternalCopyError::CopyInto (this=0x7fffe0001930) at ../src/external_copy/external_copy.cc:336
#2  0x00007ffff41f76b9 in ivm::ThreePhaseTask::Phase2Runner::Phase3Failure::Run (this=0x7fffe00017c0) at ../src/isolate/three_phase_task.cc:129
#3  0x00007ffff41ec5ef in ivm::IsolateEnvironment::AsyncEntry (this=this@entry=0x440e5f0) at ../src/isolate/environment.cc:222
#4  0x00007ffff41f3de4 in ivm::Scheduler::Implementation::<lambda(uv_async_t*)>::operator() (__closure=0x0, async=<optimized out>)
    at ../src/isolate/scheduler.cc:37
#5  ivm::Scheduler::Implementation::<lambda(uv_async_t*)>::_FUN(uv_async_t *) () at ../src/isolate/scheduler.cc:46
#6  0x0000000001324749 in uv.async_io.part () at ../deps/uv/src/unix/async.c:150
#7  0x0000000001336bb0 in uv.io_poll () at ../deps/uv/src/unix/linux-core.c:431
#8  0x0000000001325058 in uv_run (loop=0x4290ea0 <default_loop_struct>, mode=UV_RUN_DEFAULT) at ../deps/uv/src/unix/core.c:381
#9  0x0000000000a6b914 in node::NodeMainInstance::Run() ()
#10 0x00000000009fae31 in node::Start(int, char**) ()
#11 0x00007ffff6ca3b97 in __libc_start_main (main=0x993d80 <main>, argc=2, argv=0x7fffffffdf58, init=<optimized out>, fini=<optimized out>, ```
