### PR TITLE
updating the OSX dependency to 10.12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,7 @@
 					'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 					'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
 					'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
-					'MACOSX_DEPLOYMENT_TARGET': '10.9',
+					'MACOSX_DEPLOYMENT_TARGET': '10.12',
 				},
 				'msvs_settings': {
 					'VCCLCompilerTool': {


### PR DESCRIPTION
Building on Mac results in the following error:
```
npm ERR! ../src/isolate/../lib/lockable.h:93:21: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12
npm ERR!         using Mutex = std::shared_timed_mutex;
```

Updating the dependency to resolve this.