### PR TITLE
Add ScriptOrigin to ContextEvalOptions types

### DIFF
--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -219,8 +219,8 @@ declare module "isolated-vm" {
 		release(): void;
 	}
 
-	export type ContextEvalOptions = RunOptions & TransferOptions;
-	export type ContextEvalClosureOptions = RunOptions & TransferOptionsBidirectional;
+	export type ContextEvalOptions = RunOptions & ScriptOrigin & TransferOptions;
+	export type ContextEvalClosureOptions = RunOptions & ScriptOrigin & TransferOptionsBidirectional;
 
 	/**
 	 * A script is a compiled chunk of JavaScript which can be executed in any context within a single


### PR DESCRIPTION
This simply seemed to be omitted.  See the docs:
https://github.com/laverdet/isolated-vm/tree/56cc60b3486536ac3f90613fd0ec5fa58ef2c193#contextevalcode-options-promise