### PR TITLE
Add cpu profiler capability to isolate

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ when you transfer a `Reference` instance via some method which accepts transfera
 will also include underlying reference handles created by isolated-vm like `Script` or `Context`
 objects.
 
+##### `isolate.createCpuProfiler()` *[CpuProfiler]*
+Create a one-time use CPU profiler, for performance profiling
+
+* **return** A [`CpuProfiler`](#class-cpu-profiler) object.
 
 ### Class: `Context` *[transferable]*
 A context is a sandboxed execution environment within an isolate. Each context contains its own
@@ -558,6 +562,22 @@ will still remain in memory, but this handle will no longer be active. Disposing
 instances isn't super important, v8 is a lot better at cleaning these up automatically because
 there's no inter-isolate dependencies.
 
+### Class: `CpuProfiler`
+A CpuProfiler is a one time use cpu profiler allows you to run cpu profiling against the application
+running inside a specific `isolate`.
+
+##### `profiler.startProfiling(title, recordSamples)` *[v8 CPUProfiler::StartProfiling](https://v8docs.nodesource.com/node-16.0/d2/d34/classv8_1_1_cpu_profiler.html#adc48f6de278c03fde38e74e6f1bd63a6)*
+
+* `title` *[string]*
+* `recordSamples` *[boolean]* 
+
+#### `profiler.stopProfiling(title)`
+Stop the CPU profiling, the title should be the same as the one used in `startProfiling`.
+After calling this API, the profiler will be disposed. If you want to run cpu profiling
+again, you will need to call `isolate.createCpuProfiler()` again for a new CPU Profiler.
+
+* `title` *[string]* should be the same string as `startProfiling`
+* **return** *[CpuProfile]*
 
 ### Shared Options
 Many methods in this library accept common options between them. They are documented here instead of
@@ -605,6 +625,28 @@ function may ignore the value, throw, or wrap it in a reference depending on the
 More advanced situations like transferring ownership of `ArrayBuffer` instances will require direct
 use of [`ExternalCopy`](#class-externalcopy-transferable) or
 [`Reference`](#class-reference-transferable).
+
+##### `CpuProfile`
+The CpuProfile Object that can be `JSON.stringify(cpuProfile)`, and save to any external file system
+for later reloaded into chrome dev tool or any other js performance tool to review.
+
+* `title` *[string]* - The profile title.
+* `startTime` *[number]* - The start timestamp when calling `.startProfiling`.
+* `endTime` *[number]* - The end timestamp when calling `.stopProfiling`,
+* `samples` *[Array<number>]* - All sample node id has been collected.
+* `timeDeltas` *[Array<number>]* - All the time deltas related to the `samples`.
+* `nodes` *[Array<Node>]*
+	* `hitCount` *[number]*
+	* `id` *[id]*
+	* `children` *[Array<number>]*
+	* `callFrame` *[CallFrame]*
+		* `functionName` *[string]*
+		* `url` *[string]* - The `filename` used in [`ScriptOrigin`](#scriptorigin)
+		* `scriptId` *[number]*
+		* `lineNumber` *[number]*
+		* `columnNumber` *[number]*
+		* `bailoutReason` *[string?]* - When the JavaScript function bailed out from v8 optimization,
+			this field will present.
 
 
 EXAMPLES

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ will also include underlying reference handles created by isolated-vm like `Scri
 objects.
 
 ##### `isolate.createCpuProfiler()` *[CpuProfiler]*
-Create a one-time use CPU profiler, for performance profiling
+Create a CPU profiler, for performance profiling
 
 * **return** A [`CpuProfiler`](#class-cpu-profiler) object.
 
@@ -563,8 +563,8 @@ instances isn't super important, v8 is a lot better at cleaning these up automat
 there's no inter-isolate dependencies.
 
 ### Class: `CpuProfiler`
-A CpuProfiler is a one time use cpu profiler allows you to run cpu profiling against the application
-running inside a specific `isolate`.
+A CpuProfiler is a cpu profiler allows you to run cpu profiling against the application
+running inside a specific `isolate`. Which works similar to `console.profile` & `console.profileEnd`.
 
 ##### `profiler.startProfiling(title, recordSamples)` *[v8 CPUProfiler::StartProfiling](https://v8docs.nodesource.com/node-16.0/d2/d34/classv8_1_1_cpu_profiler.html#adc48f6de278c03fde38e74e6f1bd63a6)*
 
@@ -578,6 +578,9 @@ again, you will need to call `isolate.createCpuProfiler()` again for a new CPU P
 
 * `title` *[string]* should be the same string as `startProfiling`
 * **return** *[CpuProfile]*
+
+#### `profiler.dispose()`
+Cleanup the cpu profiler from `v8` to release the resources occupied by the CPU profiler.
 
 ### Shared Options
 Many methods in this library accept common options between them. They are documented here instead of

--- a/binding.gyp
+++ b/binding.gyp
@@ -87,6 +87,7 @@
 				'src/module/script_handle.cc',
 				'src/module/session_handle.cc',
 				'src/module/transferable.cc',
+				"src/module/cpu_profiler_handle.cc"
 			],
 			'conditions': [
 				[ 'OS != "win"', {

--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -612,6 +612,11 @@ declare module "isolated-vm" {
 		 * @param title The title of cpu profile
 		 */
 		stopProfiling(title: string): CpuProfile;
+
+		/**
+		 * Dispose the CpuProfiler
+		 */
+		dispose(): void;
 	}
 
 	export type CpuProfile = {

--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -106,6 +106,17 @@ declare module "isolated-vm" {
 		 */
 		getHeapStatistics(): Promise<HeapStatistics>;
 		getHeapStatisticsSync(): HeapStatistics;
+
+		/**
+		 * Returns a Cpu Profiler from v8 for this specific isolate.
+		 * 
+		 * This function only returns a `single-use` CpuProfiler, once the
+		 * `stopProfiling` is called, it will automatically dispose the
+		 * `CpuProfiler`. 
+		 * 
+		 * Any new CPU profiling require to call this function again. 
+		 */
+		createCpuProfiler(): CpuProfiler;
 	}
 
 	export type IsolateOptions = {
@@ -585,6 +596,43 @@ declare module "isolated-vm" {
 		 * @param context Context to initialize the module with.
 		 */
 		createSync(context: Context): Reference<any>;
+	}
+
+	export class CpuProfiler {
+
+		/**
+		 * Similar to `console.profile(title)`
+		 * @param title The title of the cpu profile
+		 * @param recordSample Should record sample or not, `true` to genereate data.
+		 */
+		startProfiling(title: string, recordSample: boolean);
+
+		/**
+		 * Similar to `console.profileEnd(title)`
+		 * @param title The title of cpu profile
+		 */
+		stopProfiling(title: string): CpuProfile;
+	}
+
+	export type CpuProfile = {
+		title: string;
+		startTime: number;
+		endTime: number;
+		samples: number[];
+		timeDeltas: number[];
+		nodes: Array<{
+			id: number;
+			hitCount: number;
+			children: number[];
+			callFrame: {
+				functionName: string;
+				url: string;
+				scriptId: number;
+				lineNubmer: number;
+				columnNumber: number;
+				bailoutReason?: string;
+			};
+		}>;
 	}
 
 	export type InspectorSession = {

--- a/src/isolate/strings.h
+++ b/src/isolate/strings.h
@@ -97,6 +97,24 @@ class StringTable {
 		String total_heap_size_executable{"total_heap_size_executable"};
 		String total_physical_size{"total_physical_size"};
 		String used_heap_size{"used_heap_size"};
+
+		// CPU Profiler specific keys
+		String startTime{"startTime"};
+		String endTime{"endTime"};
+		String samples{"samples"};
+		String timeDeltas{"timeDeltas"};
+		String nodes{"nodes"};
+		String id{"id"};
+		String callFrame{"callFrame"};
+		String functionName{"functionName"};
+		String scriptId{"scriptId"};
+		String url{"url"};
+		String lineNumber{"lineNumber"};
+		String columnNumber{"columnNumber"};
+		String hitCount{"hitCount"};
+		String children{"children"};
+		String title{"title"};
+		String bailoutReason{"bailoutReason"};
 };
 
 inline auto HandleCastImpl(

--- a/src/module/cpu_profiler_handle.cc
+++ b/src/module/cpu_profiler_handle.cc
@@ -1,0 +1,153 @@
+#include "cpu_profiler_handle.h"
+
+#include <exception>
+#include <typeinfo>
+#include <stdexcept>
+#include <cstring>
+
+using namespace v8;
+
+namespace ivm {
+
+auto CpuProfilerHandle::Definition() -> Local<FunctionTemplate> {
+    return MakeClass(
+		"CpuProfiler", nullptr,
+        "startProfiling", MemberFunction<decltype(&CpuProfilerHandle::StartProfiling), &CpuProfilerHandle::StartProfiling>{},
+		"stopProfiling", MemberFunction<decltype(&CpuProfilerHandle::StopProfiling<1>), &CpuProfilerHandle::StopProfiling<1>>{},
+        "setSamplingInterval", MemberFunction<decltype(&CpuProfilerHandle::SetSamplingInterval), &CpuProfilerHandle::SetSamplingInterval>{},
+        "setUsePreciseSampling", MemberFunction<decltype(&CpuProfilerHandle::SetUsePreciseSampling), &CpuProfilerHandle::SetUsePreciseSampling>{}
+	);
+}
+
+CpuProfilerHandle::CpuProfilerHandle(v8::CpuProfiler* profiler) : profiler(profiler) {} 
+
+void CpuProfilerHandle::FlatNodes(const v8::CpuProfileNode* node, std::vector<const v8::CpuProfileNode*>* nodes) {
+    nodes->push_back(node);
+    uint32_t childrenCount = node->GetChildrenCount();
+
+    for (uint32_t index = 0; index < childrenCount; ++index) {
+        FlatNodes(node->GetChild(index), nodes);
+    }
+}
+
+void CpuProfilerHandle::StartProfiling(Local<String> title, Local<Boolean> recordSamples) {
+    if (!profiler) {
+        throw RuntimeGenericError("`profiler` is disposed");
+    }
+
+    profiler->StartProfiling(title, recordSamples->Value());
+}
+
+template <int async> 
+auto CpuProfilerHandle::StopProfiling(v8::Local<v8::String> title) -> Local<Value> {
+    if (!profiler) {
+        throw RuntimeGenericError("`profiler` is disposed");
+    }
+    v8::CpuProfile* profile;
+
+    profile = profiler->StopProfiling(title);
+
+    Isolate* iso = Isolate::GetCurrent();
+    Local<Context> context = iso->GetCurrentContext();
+
+    v8::EscapableHandleScope handle_scope(iso);
+    Local<Object> profileObject = Object::New(iso);
+    auto& strings = StringTable::Get();
+
+    Unmaybe(profileObject->Set(context, strings.startTime, Number::New(iso, profile->GetStartTime())));
+    Unmaybe(profileObject->Set(context, strings.endTime, Number::New(iso, profile->GetEndTime())));
+    Unmaybe(profileObject->Set(context, strings.title, title));
+
+    uint64_t sampleCount = profile->GetSamplesCount();
+    Local<Array> samples = Array::New(iso, sampleCount);
+    Local<Array> timeDeltas = Array::New(iso, sampleCount);
+
+    uint64_t startTs = profile->GetStartTime();    
+    for (uint64_t i = 0; i < sampleCount; i++) {
+        Unmaybe(samples->Set(context, i, Number::New(iso, profile->GetSample(i)->GetNodeId())));
+        Unmaybe(timeDeltas->Set(context, i, Number::New(iso, profile->GetSampleTimestamp(i) - startTs)));
+    }
+    Unmaybe(profileObject->Set(context, strings.samples, samples));
+    Unmaybe(profileObject->Set(context, strings.timeDeltas, timeDeltas));
+
+    // handle nodes
+    std::vector<const v8::CpuProfileNode*> nodes;
+    FlatNodes(profile->GetTopDownRoot(), &nodes);
+    
+    size_t count = nodes.size();
+    Local<Array> nodeArr = Array::New(iso, count);
+    Unmaybe(profileObject->Set(context, strings.nodes, nodeArr));
+
+    for (size_t i = 0; i < count; i++) {
+        Local<Object> nodeObj = CreateNode(iso, nodes.at(i));
+        Unmaybe(nodeArr->Set(context, i, nodeObj));
+    }
+
+    profiler->Dispose();
+    profiler = NULL;
+
+    return handle_scope.Escape(profileObject);
+}
+
+void CpuProfilerHandle::SetSamplingInterval(Local<Number> microSecond) {
+    profiler->SetSamplingInterval((int)microSecond->Value());
+}
+
+void CpuProfilerHandle::SetUsePreciseSampling(Local<Boolean> isOn) {
+    // nodejs @ v10 does not have this method, will simply ignore
+    #if NODE_MODULE_VERSION >= 72
+        profiler->SetUsePreciseSampling(isOn->Value());
+    #endif
+}
+
+auto CpuProfilerHandle::CreateNode(Isolate *isolate, const v8::CpuProfileNode* node) -> Local<Object> {
+    auto& strings = StringTable::Get();
+    Local<Object> nodeObj = Object::New(isolate);
+    Local<Context> context = isolate->GetCurrentContext();      
+
+    Unmaybe(nodeObj->Set(context, strings.hitCount, Number::New(isolate, node->GetHitCount())));
+    Unmaybe(nodeObj->Set(context, strings.id, Number::New(isolate, node->GetNodeId())));
+
+    const char* bailoutReason = node->GetBailoutReason();
+
+    if (strlen(bailoutReason) > 0) {
+        #if NODE_MODULE_VERSION < 83
+            Unmaybe(nodeObj->Set(context, strings.bailoutReason, String::NewFromUtf8(isolate, bailoutReason)));
+        #else
+            Unmaybe(nodeObj->Set(context, strings.bailoutReason, String::NewFromUtf8(isolate, bailoutReason).ToLocalChecked()));
+        #endif
+    }
+    
+    size_t childrenCount = node->GetChildrenCount();
+    Local<Array> children = Array::New(isolate, childrenCount);
+    Unmaybe(nodeObj->Set(context, strings.children, children));
+
+    for (size_t j = 0; j < childrenCount; j++) {
+        Unmaybe(children->Set(context, j, Number::New(isolate, node->GetChild(j)->GetNodeId())));
+    }
+
+    Local<Object> callFrame = CreateCallFrame(isolate, node);
+    Unmaybe(nodeObj->Set(context, strings.callFrame, callFrame));
+    
+
+    return nodeObj;
+}
+
+auto CpuProfilerHandle::CreateCallFrame(Isolate *isolate, const v8::CpuProfileNode* node) -> Local<Object> {
+    auto& strings = StringTable::Get();
+    Local<Object> callFrame = Object::New(isolate);
+    Local<Context> context = isolate->GetCurrentContext();  
+    #if NODE_MODULE_VERSION < 83
+        Unmaybe(callFrame->Set(context, strings.functionName, String::NewFromUtf8(isolate, node->GetFunctionNameStr())));
+        Unmaybe(callFrame->Set(context, strings.url, String::NewFromUtf8(isolate, node->GetScriptResourceNameStr())));
+    #else
+        Unmaybe(callFrame->Set(context, strings.functionName, String::NewFromUtf8(isolate, node->GetFunctionNameStr()).ToLocalChecked()));
+        Unmaybe(callFrame->Set(context, strings.url, String::NewFromUtf8(isolate, node->GetScriptResourceNameStr()).ToLocalChecked()));
+    #endif
+    Unmaybe(callFrame->Set(context, strings.scriptId, Number::New(isolate, node->GetScriptId())));
+    Unmaybe(callFrame->Set(context, strings.lineNumber, Number::New(isolate, node->GetLineNumber())));
+    Unmaybe(callFrame->Set(context, strings.columnNumber, Number::New(isolate, node->GetColumnNumber())));
+    return callFrame;
+}
+
+} // end namespace ivm

--- a/src/module/cpu_profiler_handle.h
+++ b/src/module/cpu_profiler_handle.h
@@ -1,0 +1,25 @@
+#include <v8.h>
+#include <v8-profiler.h>
+#include "isolate/class_handle.h"
+
+using namespace v8;
+using v8::CpuProfiler;
+
+namespace ivm {
+
+class CpuProfilerHandle : public ClassHandle {
+    private:
+        v8::CpuProfiler* profiler;
+        void FlatNodes(const v8::CpuProfileNode* node, std::vector<const v8::CpuProfileNode*>* nodes);
+        auto CreateNode(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
+        auto CreateCallFrame(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
+    public:
+        void StartProfiling(Local<String> title, Local<Boolean> recordSamples);
+        template <int async> auto StopProfiling(Local<String> title) -> Local<Value>;
+        void SetSamplingInterval(Local<Number> us);
+        void SetUsePreciseSampling(Local<Boolean> isOn);
+        explicit CpuProfilerHandle(v8::CpuProfiler* profiler);
+        static auto Definition() -> Local<FunctionTemplate>;
+};
+
+}  // namespace ivm

--- a/src/module/cpu_profiler_handle.h
+++ b/src/module/cpu_profiler_handle.h
@@ -3,7 +3,6 @@
 #include "isolate/class_handle.h"
 
 using namespace v8;
-using v8::CpuProfiler;
 
 namespace ivm {
 
@@ -11,13 +10,14 @@ class CpuProfilerHandle : public ClassHandle {
     private:
         v8::CpuProfiler* profiler;
         void FlatNodes(const v8::CpuProfileNode* node, std::vector<const v8::CpuProfileNode*>* nodes);
-        auto CreateNode(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
-        auto CreateCallFrame(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
+        static auto CreateNode(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
+        static auto CreateCallFrame(Isolate* isolate, const v8::CpuProfileNode* node) -> Local<Object>;
     public:
         void StartProfiling(Local<String> title, Local<Boolean> recordSamples);
         template <int async> auto StopProfiling(Local<String> title) -> Local<Value>;
-        void SetSamplingInterval(Local<Number> us);
+        void SetSamplingInterval(Local<Number> microSecond);
         void SetUsePreciseSampling(Local<Boolean> isOn);
+        void Dispose();
         explicit CpuProfilerHandle(v8::CpuProfiler* profiler);
         static auto Definition() -> Local<FunctionTemplate>;
 };

--- a/src/module/isolate_handle.h
+++ b/src/module/isolate_handle.h
@@ -3,6 +3,7 @@
 #include "transferable.h"
 #include <v8.h>
 #include <memory>
+#include "cpu_profiler_handle.h"
 
 namespace ivm {
 
@@ -30,12 +31,14 @@ class IsolateHandle : public TransferableHandle {
 		template <int async> auto CreateContext(v8::MaybeLocal<v8::Object> maybe_options) -> v8::Local<v8::Value>;
 		template <int async> auto CompileScript(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options) -> v8::Local<v8::Value>;
 		template <int async> auto CompileModule(v8::Local<v8::String> code_handle, v8::MaybeLocal<v8::Object> maybe_options) -> v8::Local<v8::Value>;
+		template <int async> auto CreateCpuProfiler() -> v8::Local<v8::Value>;
 
 		auto CreateInspectorSession() -> v8::Local<v8::Value>;
 		auto Dispose() -> v8::Local<v8::Value>;
 		template <int async> auto GetHeapStatistics() -> v8::Local<v8::Value>;
 		auto GetCpuTime() -> v8::Local<v8::Value>;
 		auto GetWallTime() -> v8::Local<v8::Value>;
+		
 		auto GetReferenceCount() -> v8::Local<v8::Value>;
 		auto IsDisposedGetter() -> v8::Local<v8::Value>;
 		static auto CreateSnapshot(ArrayRange script_handles, v8::MaybeLocal<v8::String> warmup_handle) -> v8::Local<v8::Value>;

--- a/tests/cpu-profiler.js
+++ b/tests/cpu-profiler.js
@@ -1,0 +1,50 @@
+const ivm = require('isolated-vm');
+const assert = require('assert');
+
+const isolate = new ivm.Isolate();
+
+const context = isolate.createContextSync();
+
+const profiler = isolate.createCpuProfiler();
+
+profiler.startProfiling('foo', true);
+profiler.setSamplingInterval(10);
+profiler.setUsePreciseSampling(false);
+
+context.evalSync(`
+    function loopFn(${new Array(1024).fill(0).map((_, idx) => 'arg' + idx).join(',')}) {
+        let i = 0;
+        let result = 0;
+        for (i = 0; i < arguments.length; i++) {
+            result += arguments[i];
+        }
+        return result;
+    }
+
+    const foo = {};
+
+    for (let i = 1024; i > 0; i--) {
+        loopFn.bind(foo).call(new Array(i).fill(0).map((_, idx) => { 
+            if (i % 2 === 0) {
+                return idx + Math.random(i);
+            } else {
+                return idx + String(i);
+            }
+        }));
+    }
+`, {
+    filename: 'foo.js'
+});
+
+const profile = profiler.stopProfiling('foo');
+
+assert.equal(profile.title, 'foo', 'profile should have title `foo`');
+assert.ok(profile.nodes.length > 0, 'profile should have node length > 0');
+assert.ok(typeof profile.startTime === 'number', 'startTime should be a number');
+assert.ok(JSON.stringify(profile).includes('loopFn'), 'loopFn should be in the result');
+assert.ok(JSON.stringify(profile).includes('foo.js'), 'foo.js filename should be in the result');
+assert.ok(profile.samples.length === profile.timeDeltas.length && profile.samples.length > 0, 'sample and time delta should have same length');
+
+console.log('pass');
+
+

--- a/tests/cpu-profiler.js
+++ b/tests/cpu-profiler.js
@@ -37,7 +37,7 @@ context.evalSync(`
 });
 
 const profile = profiler.stopProfiling('foo');
-
+profiler.dispose();
 assert.equal(profile.title, 'foo', 'profile should have title `foo`');
 assert.ok(profile.nodes.length > 0, 'profile should have node length > 0');
 assert.ok(typeof profile.startTime === 'number', 'startTime should be a number');


### PR DESCRIPTION
Hi @laverdet ,

Thanks again for the fantastic library.

It seems like profiling can only be done via connecting to `inspector` with debug mode. So I am adding a
new method into the isolate to create a one-time CPU profiler.

The CPU profiler will be disposed of once the `stopProfiling` is called.

I am very, very new to the c++ and v8 side of changes; feel free to point out what I need to change in the
PR. I will update them asap. 

Tested in:

* node 10
* node 12
* node 14
* node 16
* node 18


- [x] fix codestyles.
- [x] changing the initialization of profiler to std::unique_ptr<v8::CpuProfile, decltype(&v8::CpuProfiler::Dispose)> profile{profiler->StopProfiling(title), &v8::CpuProfiler::Dispose};, and removing the final profiler->Dispose();
