### PR TITLE
Increase loop time to make sure node16 function name shows

### DIFF
--- a/tests/cpu-profiler.js
+++ b/tests/cpu-profiler.js
@@ -12,7 +12,7 @@ profiler.setSamplingInterval(10);
 profiler.setUsePreciseSampling(false);
 
 context.evalSync(`
-    function loopFn(${new Array(1024).fill(0).map((_, idx) => 'arg' + idx).join(',')}) {
+    function loopFn(${new Array(2048).fill(0).map((_, idx) => 'arg' + idx).join(',')}) {
         let i = 0;
         let result = 0;
         for (i = 0; i < arguments.length; i++) {
@@ -23,7 +23,7 @@ context.evalSync(`
 
     const foo = {};
 
-    for (let i = 1024; i > 0; i--) {
+    for (let i = 2048; i > 0; i--) {
         loopFn.bind(foo).call(new Array(i).fill(0).map((_, idx) => { 
             if (i % 2 === 0) {
                 return idx + Math.random(i);


### PR DESCRIPTION
hi @laverdet ,

I found out that when the node process does not have enough samples, it discards the function name, which causes the CPU-profiler test to be flaky.

So I increased the loop count by double, seems like it never fails locally anymore after increasing the loop count(apple m1max locally). I will update the test if it continues to happen. I may remove the function name check in the future if it keeps happening.