### PR TITLE
fix deadlock when sync error triggered

### DIFF
--- a/src/isolate/three_phase_task.cc
+++ b/src/isolate/three_phase_task.cc
@@ -333,6 +333,7 @@ auto ThreePhaseTask::RunSync(IsolateHolder& second_isolate, bool allow_async) ->
 						this->error = IsolateEnvironment::GetCurrent()->TaskEpilogue();
 					}, [ this ](unique_ptr<ExternalCopy> error) {
 						this->error = std::move(error);
+						wait.Done();
 					});
 				}
 			};

--- a/tests/sync-error-deadlock.js
+++ b/tests/sync-error-deadlock.js
@@ -1,0 +1,40 @@
+const ivm = require('isolated-vm');
+
+const isolate = new ivm.Isolate();
+
+const task = async () => {
+    const context = await isolate.createContext();
+
+    await context.global.set("getProm", () => {
+        throw new Error('test')
+    }, { reference: true });
+
+    await context.global.set("pass", () => {
+        console.log('pass');
+    }, { reference: true });
+
+
+    timeout = setTimeout(() => {
+        console.error('Deadlock check time out');
+        process.exitCode = 1;
+        process.exit(1);
+    }, 1000);
+
+    await context.eval(`
+        try {
+            getProm.applySync();
+        } catch {
+            pass.applySync();
+        }
+    `);
+
+    clearTimeout(timeout);
+
+    context.release();
+}
+
+task().catch(e => {
+    console.error(e);
+    process.exitCode = 1;
+    process.exit();
+});


### PR DESCRIPTION
Hi @laverdet ,

Found out where the deadlock comes from in 4.4.2.

When an error is thrown in the main thread's handler, the `wait` never gets `Done`, so the other thread keeps waiting. This PR should fix that issue.
