### PR TITLE
prebuild on ubuntu 20.04

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
this allows to use the prebuilt images on systems that do not have glibc v3 installed, e.g. the official selenium and cypress docker images