### PR TITLE
Improve support for reloading module in multiple workers

### DIFF
--- a/src/module/isolate.cc
+++ b/src/module/isolate.cc
@@ -131,4 +131,6 @@ void init(Local<Object> target) {
 
 } // namespace ivm
 
-NODE_MODULE_CONTEXT_AWARE(isolated_vm, ivm::init) // NOLINT
+NODE_MODULE_INIT(/* exports, module, context */) {
+	ivm::init(exports);
+}

--- a/tests/worker-reload.js
+++ b/tests/worker-reload.js
@@ -1,0 +1,12 @@
+const { Worker } = require('worker_threads');
+
+(async function () {
+    for (let i = 0; i < 2; i++) {
+        const worker = new Worker("require('isolated-vm')", { eval: true });
+        await new Promise((resolve, reject) => {
+            worker.on('exit', code => code ? reject(new Error(`Worker exited with code: ${code}`)) : resolve());
+            worker.on('error', error => reject(error));
+        });
+    }
+    console.log('pass')
+})().catch(console.error);

--- a/tests/worker-reload.js
+++ b/tests/worker-reload.js
@@ -1,5 +1,11 @@
 const { Worker } = require('worker_threads');
 
+if (process.platform === 'win32') {
+    // unloading the module segfaults on Windows, skip for now
+    console.log('pass');
+	process.exit();
+}
+
 (async function () {
     for (let i = 0; i < 2; i++) {
         const worker = new Worker("require('isolated-vm')", { eval: true });


### PR DESCRIPTION
### Summary
Loading the module in one worker, closing that worker again, and then trying to load the module in a second worker fails with `Error: Module did not self-register`. From what I can tell, the core issue is this one: https://github.com/nodejs/node/issues/48353.

This should fix the issue, which was also mentioned in this comment: https://github.com/laverdet/isolated-vm/issues/138#issuecomment-1077856679. I'm however not too familiar with native Node.js addon development, so I'm unsure if this has any unintended side effects (it really shouldn't, though).

#### Details
Node.js unloads unreferenced native addons if not on the main thread[^1], but the shared object doesn't necessarily get fully unloaded from calling `dlclose()` (at least on Linux, due to... reasons?), which means it won't self-register when `dlopen()`ing it again from a second worker.

This doesn't happen if isolated-vm is also loaded in the main thread, since Node.js won't unload it in that case. This is the only real workaround I've found so far.

Node.js additionally looks for a well-known export when the module didn't self-register[^2], but isolated-vm didn't use the `NODE_MODULE_INIT` macro that produces this name, and instead relied on the self-register mechanism (which, to be fair, works fine in most cases).

### Reproducible Code
(nodejs v18.17.1, ubuntu 22.04)
```js
const { Worker } = require('worker_threads');

(async function () {
    for (let i = 0; i < 2; i++) {
        console.log(`creating worker ${i}`);
        const worker = new Worker("require('isolated-vm')", { eval: true });
        await new Promise((resolve, reject) => {
            worker.on('exit', code => code ? reject(new Error(`Worker exited with code: ${code}`)) : resolve());
            worker.on('error', error => reject(error));
        });
        console.log(`worker ${i} finished`);
    }
})().catch(console.error);
```

```sh
creating worker 0
worker 0 finished
creating worker 1
node:internal/modules/cjs/loader:1340
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: Module did not self-register: .../node_modules/isolated-vm/out/isolated_vm.node'.
```

Worth mentioning that the added testcase gets skipped on Windows, which seems to actually try to unload the module properly when the first worker exits, and runs into a segfault instead. Unrelated to the change in this PR, though.

[^1]: https://github.com/nodejs/node/blob/48fcb205e4577fd0096f6b772ca250c6dbf759e3/src/env.cc#L985-L995
[^2]: https://github.com/nodejs/node/blob/668437ccada33c03bb454a19c61b030c028076b0/src/node_binding.cc#L490-L492 + second paragraph in the [docs](https://nodejs.org/api/addons.html#context-aware-addons)