### PR TITLE
Scale node-gyp automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=16.0.0"
   },
   "scripts": {
-    "install": "prebuild-install || (node-gyp rebuild --release -j 4 && node-gyp clean)",
+    "install": "prebuild-install || (node-gyp rebuild --release -j max && node-gyp clean)",
     "rebuild": "node-gyp rebuild --release -j 4",
     "prebuild": "prebuild",
     "upload": "prebuild --upload ${GITHUB_TOKEN}",


### PR DESCRIPTION
This change let node-gyp choose the number of jobs to build during initial installation. This avoids threshing smaller machines with low RAM/CPUs.