### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/isolate/allocator_nortti.cc
+++ b/src/isolate/allocator_nortti.cc
@@ -21,7 +21,7 @@ class ExternalMemoryHandle {
 		~ExternalMemoryHandle() {
 			auto* allocator = IsolateEnvironment::GetCurrent().GetLimitedAllocator();
 			if (allocator != nullptr) {
-				allocator->AdjustAllocatedSize(-size);
+				allocator->AdjustAllocatedSize(-static_cast<ptrdiff_t>(size));
 			}
 		};
 

--- a/src/isolate/environment.cc
+++ b/src/isolate/environment.cc
@@ -55,7 +55,6 @@ static auto GetStackBase() -> void* {
   return base;
 }
 #elif defined __unix__
-#define _GNU_SOURCE
 static auto GetStackBase() -> void* {
 	pthread_t self = pthread_self();
 	pthread_attr_t attrs;


### PR DESCRIPTION
* Remove pointless #define _GNU_SOURCE. It is already defined by gyp, and defining it after all the includes does nothing anyway.
* unary minus operator applied to unsigned type, result still unsigned
