### PR TITLE
Fix copying of BigInt64Array and BigUint64Array

### DIFF
--- a/src/external_copy/external_copy.cc
+++ b/src/external_copy/external_copy.cc
@@ -151,9 +151,9 @@ auto ExternalCopy::Copy(Local<Value> value, bool transfer_out, ArrayRange transf
 		} else if (view->IsFloat64Array()) {
 			type = ViewType::Float64;
 		} else if (view->IsBigInt64Array()) {
-			type = ViewType::BigInt64Array;
+			type = ViewType::BigInt64;
 		} else if (view->IsBigUint64Array()) {
-			type = ViewType::BigUint64Array;
+			type = ViewType::BigUint64;
 		} else if (view->IsDataView()) {
 			type = ViewType::DataView;
 		} else {
@@ -486,6 +486,10 @@ auto NewTypedArrayView(Local<T> buffer, ExternalCopyArrayBufferView::ViewType ty
 			return Float32Array::New(buffer, byte_offset, byte_length >> 2);
 		case ExternalCopyArrayBufferView::ViewType::Float64:
 			return Float64Array::New(buffer, byte_offset, byte_length >> 3);
+		case ExternalCopyArrayBufferView::ViewType::BigInt64:
+			return BigInt64Array::New(buffer, byte_offset, byte_length >> 3);
+		case ExternalCopyArrayBufferView::ViewType::BigUint64:
+			return BigUint64Array::New(buffer, byte_offset, byte_length >> 3);
 		case ExternalCopyArrayBufferView::ViewType::DataView:
 			return DataView::New(buffer, byte_offset, byte_length);
 		default:

--- a/src/external_copy/external_copy.h
+++ b/src/external_copy/external_copy.h
@@ -102,7 +102,7 @@ class ExternalCopySharedArrayBuffer : public ExternalCopyAnyBuffer {
  */
 class ExternalCopyArrayBufferView : public ExternalCopy {
 	public:
-		enum class ViewType { Uint8, Uint8Clamped, Int8, Uint16, Int16, Uint32, Int32, Float32, Float64, BigInt64Array, BigUint64Array, DataView };
+		enum class ViewType { Uint8, Uint8Clamped, Int8, Uint16, Int16, Uint32, Int32, Float32, Float64, BigInt64, BigUint64, DataView };
 
 	private:
 		std::unique_ptr<ExternalCopyAnyBuffer> buffer;


### PR DESCRIPTION
It seems the support for copying `Big{Int64,Uint64}Array`s added with 2d06cc30ba5200e8a8d70e7b5022b5750902b1ce is incomplete. Presently, the following results in a crash:

```js
import ivm from 'isolated-vm';

const isolate = new ivm.Isolate();
const context = await isolate.createContext();

const array = await context.eval('new BigUint64Array(12345)', { copy: true }); // crashes
console.log(array);
```

The crash is caused by the `NewTypedArrayView` function called by `ExternalCopyArrayBufferView::CopyInto`. It does not cover the `Big{Int64,Uint64}Array` types and instead throws a `std::exception` which is not handled anywhere. This is likely an oversight, and this PR fixes it.

https://github.com/laverdet/isolated-vm/blob/be71d2512cd583ad3e51672ff9b6e1f9ef34b279/src/external_copy/external_copy.cc#L468-L494
