### PR TITLE
Update prebuild to v13

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      # https://github.com/nodejs/node-gyp/issues/2869
-      - run: python3 -m pip install setuptools
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "isolated-vm": ".",
-    "prebuild": "^12.1.0"
+    "prebuild": "^13.0.0"
   },
   "binary": {
     "module_path": "out"


### PR DESCRIPTION
This updates node-gyp dependency, and should fix the build on macos.