### PR TITLE
fix incorrect types of pointers

### DIFF
--- a/src/isolate/scheduler.cc
+++ b/src/isolate/scheduler.cc
@@ -137,7 +137,7 @@ UvScheduler::UvScheduler(IsolateEnvironment& env) :
 
 UvScheduler::~UvScheduler() {
 	uv_close(reinterpret_cast<uv_handle_t*>(uv_async), [](uv_handle_t* handle) {
-		delete handle;
+		delete reinterpret_cast<uv_async_t*>(handle);
 	});
 }
 

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -523,7 +523,7 @@ auto IsolateHandle::CreateSnapshot(ArrayRange script_handles, MaybeLocal<String>
 
 	// Create the snapshot
 	StartupData snapshot {};
-	unique_ptr<const char> snapshot_data_ptr;
+	unique_ptr<const char[]> snapshot_data_ptr;
 	shared_ptr<ExternalCopy> error;
 	{
 		Isolate* isolate;


### PR DESCRIPTION
1/ `isolate_handle.cc`:

`snapshot.data`, which is allocated by V8 as `new char[]`  ([snapshot.cc:546](https://github.com/nodejs/node/blob/d545984a02eb84ad030511d7eb7968bc1e4909be/deps/v8/src/snapshot/snapshot.cc#L546)) is owned by `snapshot_data_ptr`, which is of type `unique_ptr<const char>` => `delete` is called upon destruction, `delete[]` should be called instead

=> changed the type of the unique_ptr to reflect this

---

2/ `scheduler.cc`:

`uv_async` is allocated as `uv_async_t` (128 B) but deleted as `uv_handle_t` (96 B)

=> added a cast back from `uv_handle_t*` to `uv_async_t*` before deleting

---

Technically, these situations are UB, but practically they don't cause any issues. They came up as a result of running the test suite with ASan which doesn't complain anymore after this trivial fix.