### PR TITLE
Fixed Issue-538

### DIFF
--- a/go_build.py
+++ b/go_build.py
@@ -1,0 +1,109 @@
+# -*- encoding: utf-8 -*-
+
+"""
+全平台一键编译 isolated-vm 的工具脚本
+
+author: Xia
+"""
+
+import os
+import shutil
+import subprocess
+import argparse
+
+def run_command_only_value(*cmd):
+    try:
+        return subprocess.check_output(
+            [str(_) for _ in cmd],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            shell=os.sep != '/'
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    pass
+
+def run_command_for_ok(*cmd):
+    try:
+        return subprocess.run(
+            [str(_) for _ in cmd],
+            cwd='.',
+            shell=os.sep != '/'
+        ).returncode
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return 1
+    pass
+
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(description="isolated-vm编译工具")
+    parser.add_argument("-C", "--init", help="是否生成 compile_commands.json", action="store_true")
+    args = parser.parse_args()
+    
+    # Node
+    if not shutil.which("node"):
+        print()
+        print("Build >> 未检测到 Node.js 环境, 请安装 Node.js 环境.")
+        print("Build >> 推荐 Node v22.19.0 -> https://nodejs.org/en/download")
+        print()
+        exit(1)
+        pass
+    
+    print(f"\n检测到 Node.js 环境: {run_command_only_value('node', '--version')}")
+    
+    # npm
+    if not shutil.which("npm"):
+        print()
+        print("Build >> 未检测到 NPM 环境, 请安装 NPM 环境.")
+        print()
+        exit(1)
+        pass
+    
+    print(f"检测到 NPM 环境: v{run_command_only_value('npm', '--version')}")
+    
+    # node-gyp
+    if not shutil.which("node-gyp"):
+        print()
+        gyp_flag = str(input("Build >> 未检测到 node-gyp 环境, 是否安装? (y/n)[默认y]: "))
+        
+        if gyp_flag == 'n':
+            print("正在退出编译程序...")
+            print()
+            exit(1)
+            pass
+        
+        os.system("npm install -g node-gyp")
+        print()
+        pass
+    
+    print(f"检测到 node-gyp: {run_command_only_value('node-gyp', '--version')}")
+    
+    # compile_commands.json
+    if args.init:
+        
+        print("\nBuild >> 生成 compile_commands.json 中...\n")
+        
+        os.system("node-gyp configure -- -f gyp.generator.compile_commands_json.py")
+        
+        print("\nBuild >> compile_commands.json 生成完毕\n")
+        
+        # 自动将 compile_commands.json 移动到根目录
+        shutil.move("./build/Release/compile_commands.json", './compile_commands.json')
+        
+        pass
+    
+    print("\nBuild >> 开始编译任务...")
+    
+    compile_flag = run_command_for_ok("npm", "run", 'rebuild')
+    
+    if compile_flag == 0:
+        
+        shutil.move("./build/Release/isolated_vm.node", './out/isolated_vm.node')
+        
+        print("\nBuild >> 编译成功, 已自动移动结果到 ./out 下\n")
+    else:
+        print("\nBuild >> 编译失败!")
+        pass
+    
+    
+    pass

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "prebuild-install": "^7.1.3"
+    "prebuild-install": "^7.1.3",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "isolated-vm": ".",

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -327,7 +327,11 @@ auto IsolateHandle::CreateInspectorSession() -> Local<Value> {
 	if (env->GetInspectorAgent() == nullptr) {
 		throw RuntimeGenericError("Inspector is not enabled for this isolate");
 	}
-	return ClassHandle::NewInstance<SessionHandle>(*env);
+	Local<Object> instance = ClassHandle::NewInstance<SessionHandle>(*env);
+	// Set the JS handle reference for callbacks
+	auto* handle = ClassHandle::Unwrap<SessionHandle>(instance);
+	handle->SetJSHandle(instance);
+	return instance;
 }
 
 /**

--- a/src/module/session_handle.cc
+++ b/src/module/session_handle.cc
@@ -15,8 +15,7 @@ namespace ivm {
 class SessionImpl : public InspectorSession {
 	public:
 		shared_ptr<IsolateHolder> isolate; // This is the isolate that owns the session
-		RemoteHandle<Function> onNotification;
-		RemoteHandle<Function> onResponse;
+		RemoteHandle<Object> handle; // Reference to the JS SessionHandle instance
 
 		explicit SessionImpl(IsolateEnvironment& isolate) : InspectorSession(isolate) {}
 
@@ -33,62 +32,80 @@ class SessionImpl : public InspectorSession {
 
 		// These functions are invoked directly from v8
 		void sendResponse(int call_id, unique_ptr<StringBuffer> message) final {
-			if (!onResponse) {
+			if (!handle) {
 				return;
 			}
 			struct SendResponseTask : public Runnable {
 				int call_id;
 				unique_ptr<StringBuffer> message;
-				RemoteHandle<Function> onResponse;
+				RemoteHandle<Object> handle;
 
 				SendResponseTask(
-					int call_id, unique_ptr<StringBuffer> message, RemoteHandle<Function> onResponse
-				) :	call_id(call_id), message(std::move(message)), onResponse(std::move(onResponse)) {}
+					int call_id, unique_ptr<StringBuffer> message, RemoteHandle<Object> handle
+				) :	call_id(call_id), message(std::move(message)), handle(std::move(handle)) {}
 
 				void Run() final {
 					Isolate* isolate = Isolate::GetCurrent();
 					TryCatch try_catch(isolate);
+					Local<Context> context = isolate->GetCurrentContext();
+					Local<Object> obj = Deref(handle);
+					
+					// Get the onResponse callback from the JS object
+					Local<Value> callback_value;
+					if (!obj->Get(context, v8_string("onResponse")).ToLocal(&callback_value) || !callback_value->IsFunction()) {
+						return;
+					}
+					
+					Local<Function> fn = callback_value.As<Function>();
 					Local<String> string;
 					if (bufferToString(*message).ToLocal(&string)) {
-						Local<Function> fn = Deref(onResponse);
 						Local<Value> argv[2];
 						argv[0] = Integer::New(isolate, call_id);
 						argv[1] = string;
 						try {
-							Unmaybe(fn->Call(isolate->GetCurrentContext(), Undefined(isolate), 2, argv));
+							Unmaybe(fn->Call(context, Undefined(isolate), 2, argv));
 						} catch (const RuntimeError& err) {}
 					}
 				}
 			};
-			isolate->ScheduleTask(std::make_unique<SendResponseTask>(call_id, std::move(message), onResponse), false, true);
+			isolate->ScheduleTask(std::make_unique<SendResponseTask>(call_id, std::move(message), handle), false, true);
 		}
 
 		void sendNotification(unique_ptr<StringBuffer> message) final {
-			if (!onNotification) {
+			if (!handle) {
 				return;
 			}
 			struct SendNotificationTask : public Runnable {
 				unique_ptr<StringBuffer> message;
-				RemoteHandle<Function> onNotification;
+				RemoteHandle<Object> handle;
 				SendNotificationTask(
-					unique_ptr<StringBuffer> message, RemoteHandle<Function> onNotification
-				) : message(std::move(message)), onNotification(std::move(onNotification)) {}
+					unique_ptr<StringBuffer> message, RemoteHandle<Object> handle
+				) : message(std::move(message)), handle(std::move(handle)) {}
 
 				void Run() final {
 					Isolate* isolate = Isolate::GetCurrent();
 					TryCatch try_catch(isolate);
+					Local<Context> context = isolate->GetCurrentContext();
+					Local<Object> obj = Deref(handle);
+					
+					// Get the onNotification callback from the JS object
+					Local<Value> callback_value;
+					if (!obj->Get(context, v8_string("onNotification")).ToLocal(&callback_value) || !callback_value->IsFunction()) {
+						return;
+					}
+					
+					Local<Function> fn = callback_value.As<Function>();
 					Local<String> string;
 					if (bufferToString(*message).ToLocal(&string)) {
-						Local<Function> fn = Deref(onNotification);
 						Local<Value> argv[1];
 						argv[0] = string;
 						try {
-							Unmaybe(fn->Call(isolate->GetCurrentContext(), Undefined(isolate), 1, argv));
+							Unmaybe(fn->Call(context, Undefined(isolate), 1, argv));
 						} catch (const RuntimeError& err) {}
 					}
 				}
 			};
-			isolate->ScheduleTask(std::make_unique<SendNotificationTask>(std::move(message), onNotification), false, true);
+			isolate->ScheduleTask(std::make_unique<SendNotificationTask>(std::move(message), handle), false, true);
 		}
 
 		void flushProtocolNotifications() final {}
@@ -105,16 +122,12 @@ auto SessionHandle::Definition() -> Local<FunctionTemplate> {
 	return MakeClass(
 		"Session", nullptr,
 		"dispatchProtocolMessage", MemberFunction<decltype(&SessionHandle::DispatchProtocolMessage), &SessionHandle::DispatchProtocolMessage>{},
-		"dispose", MemberFunction<decltype(&SessionHandle::Dispose), &SessionHandle::Dispose>{},
-		"onNotification", MemberAccessor<
-			decltype(&SessionHandle::OnNotificationGetter), &SessionHandle::OnNotificationGetter,
-			decltype(&SessionHandle::OnNotificationSetter), &SessionHandle::OnNotificationSetter
-		>{},
-		"onResponse", MemberAccessor<
-			decltype(&SessionHandle::OnResponseGetter), &SessionHandle::OnResponseGetter,
-			decltype(&SessionHandle::OnResponseSetter), &SessionHandle::OnResponseSetter
-		>{}
+		"dispose", MemberFunction<decltype(&SessionHandle::Dispose), &SessionHandle::Dispose>{}
 	);
+}
+
+void SessionHandle::SetJSHandle(Local<Object> js_handle) {
+	session->handle = RemoteHandle<Object>(js_handle);
 }
 
 void SessionHandle::CheckDisposed() {
@@ -138,36 +151,6 @@ auto SessionHandle::Dispose() -> Local<Value> {
 	CheckDisposed();
 	session.reset();
 	return Undefined(Isolate::GetCurrent());
-}
-
-// .onNotification
-auto SessionHandle::OnNotificationGetter() -> Local<Value> {
-	CheckDisposed();
-	if (session->onNotification) {
-		return Deref(session->onNotification);
-	} else {
-		return Undefined(Isolate::GetCurrent());
-	}
-}
-
-void SessionHandle::OnNotificationSetter(Local<Function> value) {
-	CheckDisposed();
-	session->onNotification = RemoteHandle<Function>(value);
-}
-
-// .onResponse
-auto SessionHandle::OnResponseGetter() -> Local<Value> {
-	CheckDisposed();
-	if (session->onResponse) {
-		return Deref(session->onResponse);
-	} else {
-		return Undefined(Isolate::GetCurrent());
-	}
-}
-
-void SessionHandle::OnResponseSetter(Local<Function> value) {
-	CheckDisposed();
-	session->onResponse = RemoteHandle<Function>(value);
 }
 
 } // namespace ivm

--- a/src/module/session_handle.h
+++ b/src/module/session_handle.h
@@ -19,13 +19,10 @@ class SessionHandle : public ClassHandle {
 		explicit SessionHandle(IsolateEnvironment& isolate);
 		static auto Definition() -> v8::Local<v8::FunctionTemplate>;
 
+		void SetJSHandle(v8::Local<v8::Object> js_handle);
 		void CheckDisposed();
 		auto DispatchProtocolMessage(v8::Local<v8::String> message) -> v8::Local<v8::Value>;
 		auto Dispose() -> v8::Local<v8::Value>;
-		auto OnNotificationGetter() -> v8::Local<v8::Value>;
-		void OnNotificationSetter(v8::Local<v8::Function> value);
-		auto OnResponseGetter() -> v8::Local<v8::Value>;
-		void OnResponseSetter(v8::Local<v8::Function> value);
 };
 
 } // namespace ivm


### PR DESCRIPTION
Issue: #538 

1. Fixed the issue where Node v22 and above cannot debug in Google Chrome using Inspect.
2. Added a script `go_build.py` for quick compilation and generating compile_commands.json

<img width="829" height="205" alt="image" src="https://github.com/user-attachments/assets/7ea6a9a3-8a5a-40ea-86e3-2c93ce2e692d" />
<img width="1914" height="1034" alt="image" src="https://github.com/user-attachments/assets/8fa7f9d8-252b-4ac4-bd09-f572d109fcbf" />