### PR TITLE
Fix crash when async instantiate() resolve callback throws synchronously

### DIFF
--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -3,6 +3,7 @@
 #include "reference_handle.h"
 #include "transferable.h"
 #include "isolate/class_handle.h"
+#include "isolate/functor_runners.h"
 #include "isolate/run_with_timeout.h"
 #include "isolate/three_phase_task.h"
 
@@ -406,13 +407,29 @@ class ModuleLinkerAsync : public ModuleLinker::Implementation {
 
 		using ModuleLinker::Implementation::Implementation;
 		auto Begin(ModuleHandle& module, RemoteHandle<Context> context) -> Local<Value> final {
-			GetLinker().Link(&module);
+			auto promise = async_handles.Deref<0>()->GetPromise();
+			bool failed = false;
+			FunctorRunners::RunCatchValue(
+				[&]() {
+					GetLinker().Link(&module);
+				},
+				[&](Local<Value> error) {
+					// The resolve callback threw synchronously. Reject the returned promise (mirroring the
+					// rejected-promise path in ModuleRejected), then Reset() -- which destroys this impl, so
+					// it must come last and nothing below may touch members.
+					Unmaybe(async_handles.Deref<0>()->Reject(Isolate::GetCurrent()->GetCurrentContext(), error));
+					GetLinker().Reset();
+					failed = true;
+				});
+			if (failed) {
+				return promise;
+			}
 			info = module.GetInfo();
 			this->context = std::move(context);
 			if (pending == 0) {
 				Instantiate();
 			}
-			return async_handles.Deref<0>()->GetPromise();
+			return promise;
 		}
 };
 

--- a/tests/module-resolve-throws.js
+++ b/tests/module-resolve-throws.js
@@ -1,0 +1,28 @@
+const ivm = require('isolated-vm');
+const assert = require('assert');
+
+function rejects(fn, re) {
+	return fn().then(
+		() => { throw new Error('Promise did not reject'); },
+		err => { assert(re.test(err.message), `unexpected rejection: ${err.message}`); });
+}
+
+(async function() {
+	const isolate = new ivm.Isolate();
+	const context = await isolate.createContext();
+	// Root has two direct imports; the callback resolves the first, then throws synchronously on the
+	// second. The first import leaves a pending linker continuation outstanding when the throw escapes.
+	const root = await isolate.compileModule(`import 'a'; import 'b';`);
+	const a = await isolate.compileModule(`export default 1;`);
+	const b = await isolate.compileModule(`export default 2;`);
+
+	await rejects(() => root.instantiate(context, specifier => {
+		if (specifier === 'a') return a;
+		throw new Error('boom');
+	}), /boom/);
+
+	// Reset() should have left link state clean, so the module can be instantiated again successfully.
+	await root.instantiate(context, specifier => specifier === 'a' ? a : b);
+
+	console.log('pass');
+})().catch(err => { console.error(err); });


### PR DESCRIPTION
## Problem

When a module is linked with the **async** linker — `module.instantiate(context, callback)` — and the resolve `callback` throws **synchronously** for one import specifier *after* an earlier specifier already returned a module, the process **segfaults (SIGSEGV)** instead of rejecting the returned promise.

The **sync** linker (`instantiateSync`) handles the same throw correctly; the async path was missing the equivalent cleanup. Confirmed present on current `main` (7.0.0).

Trigger conditions (all three required):
1. The async linker (`instantiate`, not `instantiateSync`).
2. The callback throws **synchronously** (a returned rejected promise was already handled correctly).
3. At least one earlier direct specifier resolved before the throw, leaving a pending continuation outstanding.

```js
const root = isolate.compileModuleSync(`import 'a'; import 'b';`);
const a = isolate.compileModuleSync(`export default 1;`);
await root.instantiate(context, (specifier) => {
  if (specifier === 'a') return a;  // resolves -> one pending continuation
  throw new Error('boom');          // synchronous throw -> SIGSEGV
});
```

## Root cause

`ModuleLinkerAsync::Begin` called `Link()` with no guard, unlike `ModuleLinkerSync::Begin`. On a synchronous throw, `Begin` exited without calling `Reset()`, so `impl` stayed non-null and `info` stayed null. The still-pending `ModuleResolved` continuation queued by the earlier resolved specifier then ran; its `if (impl == nullptr) return;` guard did **not** fire, so it decremented `pending` to 0 and called `Instantiate()`, which dereferenced the null `info` → crash.

The rejected-promise path is safe precisely because `ModuleRejected` calls `Reset()` (nulling `impl`); the synchronous-throw path never reached that cleanup.

## Fix

Wrap `Link()` in `ModuleLinkerAsync::Begin` with `FunctorRunners::RunCatchValue` so a synchronous throw **rejects the returned promise** with the caught error and resets the linker — behaving identically to a callback that returns `Promise.reject(...)`.

Two details respected: the caught exception is a bare `RuntimeError` (the JS error lives in the isolate's TryCatch), so `RunCatchValue` is used to extract the v8 value; and `Reset()` destroys the implementation (`this`), so the promise is captured as a stack local and the resolver rejected **before** `Reset()`, mirroring the ordering in `ModuleRejected`.

## Test

Adds `tests/module-resolve-throws.js`: resolves the first import, throws on the second, and asserts the promise rejects with `boom`, then re-instantiates successfully to confirm clean reset state. Without the fix this test crashes with SIGSEGV (exit 139); with it, the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)