### PR TITLE
Fall back to node-gyp when prebuildify is unavailable

### DIFF
--- a/scripts/run-prebuild.js
+++ b/scripts/run-prebuild.js
@@ -23,8 +23,21 @@ const env = {
 
 fs.rmSync(path.join(__dirname, '..', 'prebuilds'), { recursive: true, force: true });
 
-const prebuildifyCli = require.resolve('prebuildify/bin.js');
-const result = spawnSync(process.execPath, [prebuildifyCli, ...targetArgs], { stdio: 'inherit', env });
+let command = process.execPath;
+let args;
+
+try {
+  args = [require.resolve('prebuildify/bin.js'), ...targetArgs];
+} catch (error) {
+  if (error && error.code === 'MODULE_NOT_FOUND' && error.message.includes('prebuildify/bin.js')) {
+    command = process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp';
+    args = ['rebuild', '--release', '-j', 'max'];
+  } else {
+    throw error;
+  }
+}
+
+const result = spawnSync(command, args, { stdio: 'inherit', env });
 
 if (result.error) {
   throw result.error;


### PR DESCRIPTION
Fixes #556.

This keeps the existing `prebuildify` path for maintainer prebuild generation, but falls back to the package's normal native rebuild command when `prebuildify/bin.js` cannot be resolved. That lets downstream source/offline builds avoid failing before `node-gyp` gets a chance to rebuild the addon.

Validation:
- mocked `scripts/run-prebuild.js` execution with `prebuildify/bin.js` resolvable: spawns `process.execPath` with the existing prebuildify args
- mocked `scripts/run-prebuild.js` execution with `prebuildify/bin.js` missing: spawns `node-gyp rebuild --release -j max`