### PR TITLE
Fix promise transfer settlement stalling on node 26.4+

### DIFF
--- a/src/module/transferable.cc
+++ b/src/module/transferable.cc
@@ -124,6 +124,9 @@ class TransferablePromiseHolder final : public ClassHandle {
 				} else {
 					Unmaybe(resolver->Resolve(context, value->TransferIn()));
 				}
+				// Under the nodejs isolate's explicit microtasks policy the continuations
+				// queued above would wait for an unrelated callback to run a checkpoint.
+				Isolate::GetCurrent()->PerformMicrotaskCheckpoint();
 			}
 
 			RemoteTuple<Promise::Resolver, v8::Context> resolver;

--- a/tests/promise-transfer-microtask.js
+++ b/tests/promise-transfer-microtask.js
@@ -1,0 +1,20 @@
+const ivm = require('isolated-vm');
+
+(async () => {
+	const isolate = new ivm.Isolate;
+	const context = await isolate.createContext();
+	await context.evalClosure(
+		'sleep = ms => $0.applySync(undefined, [ ms ], { result: { promise: true } })',
+		[ ms => new Promise(resolve => setTimeout(resolve, ms)) ],
+		{ arguments: { reference: true } },
+	);
+	// The transferred promise must settle on its own, without waiting for
+	// another callback to wake the microtask queue.
+	setTimeout(() => {
+		console.log('fail');
+		process.exit();
+	}, 10000);
+	await context.eval('sleep(5)', { promise: true });
+	console.log('pass');
+	process.exit();
+})();


### PR DESCRIPTION
## Problem

When a promise crosses isolates with `{ promise: true }`, the other side receives its own promise which is settled later by `TransferablePromiseHolder::ResolveTask`. In the nodejs isolate, microtasks run under the explicit policy, so the settlement only queues the `await` continuations. No checkpoint runs afterwards, and they sit in the queue until some other JS callback triggers one. In a process that's just holding a server or an IPC channel, that's never.

## Why node 26.4

This stayed invisible because node used to run a checkpoint on every loop iteration, as a side effect of draining native immediates even when there was nothing to drain. nodejs/node#62969 (26.4.0) skips the empty drain, and the accidental checkpoint went with it.

## Repro

```js
// main.mjs, hangs on node >= 26.4
import ivm from 'isolated-vm';
import net from 'node:net';

net.createServer().listen(0); // just something to keep the process alive

const isolate = new ivm.Isolate();
const context = await isolate.createContext();
await context.evalClosure(
	'sleep = ms => $0.applySync(undefined, [ ms ], { result: { promise: true } })',
	[ ms => new Promise(resolve => setTimeout(resolve, ms)) ],
	{ arguments: { reference: true } });

await context.eval('sleep(5)', { promise: true });
console.log('settled');
process.exit();
```

## Fix

The fix runs the checkpoint in `ResolveTask::Run` once the promise settles. Also adds a regression test, which fails on 26.4+ without the fix.