### PR TITLE
Add `onUnhandledRejection` isolate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ contains can represent quite a large chunk of memory though you may want to expl
     this is invoked it means that v8 has lost all control over the isolate, and all resources in use
     are totally unrecoverable. If you receive this error you should log the error, stop serving
     requests, finish outstanding work, and end the process by calling `process.abort()`.
+  * `onUnhandledRejection` *[function]* - Callback to be invoked when a promise is rejected without a
+    handler. By default such a rejection is thrown out of whichever call into the isolate happens to
+    be running, which may be one unrelated to the promise. If this callback is set the rejected value
+    is passed to it instead and nothing is thrown. Errors thrown by the callback are ignored.
 
 *NOTE*: `snapshot` contains compiled machine code. That means you should not accept `snapshot`
 payloads from a user, otherwise they may be able to run arbitrary code.

--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -155,6 +155,17 @@ declare namespace IsolatedVM {
 		 * work, and end the process by calling `process.abort()`.
 		 */
 		onCatastrophicError?: (message: string) => void;
+
+		/**
+		 * Callback to be invoked when a promise is rejected without a handler. By default such a
+		 * rejection is thrown out of whichever call into the isolate happens to be running, an `eval` or
+		 * an `apply` that may have nothing to do with the promise itself. If this callback is set,
+		 * nothing is thrown: each rejected value is copied out of the isolate, the way a thrown value
+		 * would be, and delivered to the callback in the isolate which created this one. For an isolate
+		 * created from node that means the callback runs on node's event loop. Errors thrown by the
+		 * callback are ignored.
+		 */
+		onUnhandledRejection?: (error: any) => void;
 	};
 
 	export type ContextOptions = {

--- a/src/isolate/environment.cc
+++ b/src/isolate/environment.cc
@@ -498,7 +498,13 @@ auto IsolateEnvironment::TaskEpilogue() -> std::unique_ptr<ExternalCopy> {
 	for (auto& handle : rejected_promises) {
 		if (!handle.IsEmpty()) {
 			Context::Scope context_scope{DefaultContext()};
-			return ExternalCopy::CopyThrownValue(Deref(handle)->Result());
+			auto error = ExternalCopy::CopyThrownValue(Deref(handle)->Result());
+			// A throw can only carry the first rejection; a handler receives every one recorded during
+			// the task.
+			if (!unhandled_rejection_handler) {
+				return error;
+			}
+			ReportUnhandledRejection(unhandled_rejection_handler, std::move(error));
 		}
 	}
 	return {};
@@ -623,6 +629,36 @@ auto RaiseCatastrophicError(RemoteHandle<Function>& handler, const char* message
 	};
 	handler.GetIsolateHolder()->ScheduleTask(std::make_unique<ErrorTask>(message, handler), false, true);
 	return true;
+}
+
+/**
+ * Delivers a rejected value to an `onUnhandledRejection` handler. The handler belongs to another
+ * isolate, usually the nodejs one, so the call is scheduled as a task on the isolate which owns it.
+ * A handler which throws is ignored, since there is nobody left to report that error to.
+ */
+void ReportUnhandledRejection(RemoteHandle<Function>& handler, std::unique_ptr<ExternalCopy> error) {
+	class RejectionTask : public Task {
+		public:
+			explicit RejectionTask(std::unique_ptr<ExternalCopy> error, RemoteHandle<Function> handler) :
+				error{std::move(error)}, handler{std::move(handler)} {}
+
+			void Run() final {
+				auto* isolate = Isolate::GetCurrent();
+				auto context = IsolateEnvironment::GetCurrent().DefaultContext();
+				Context::Scope context_scope{context};
+				TryCatch try_catch{isolate};
+				try {
+					auto fn = handler.Deref();
+					Local<Value> argv[] = { error->CopyInto() };
+					Unmaybe(fn->Call(context, Undefined(isolate), 1, argv));
+				} catch (const RuntimeError& err) {}
+			}
+
+		private:
+			std::unique_ptr<ExternalCopy> error;
+			RemoteHandle<Function> handler;
+	};
+	handler.GetIsolateHolder()->ScheduleTask(std::make_unique<RejectionTask>(std::move(error), handler), false, true);
 }
 
 } // namespace ivm

--- a/src/isolate/environment.h
+++ b/src/isolate/environment.h
@@ -117,6 +117,7 @@ class IsolateEnvironment : public std::enable_shared_from_this<IsolateEnvironmen
 
 	public:
 		RemoteHandle<v8::Function> error_handler;
+		RemoteHandle<v8::Function> unhandled_rejection_handler;
 		std::unordered_multimap<int, struct ModuleInfo*> module_handles;
 		std::unordered_map<class NativeModule*, std::shared_ptr<NativeModule>> native_modules;
 		int terminate_depth = 0;
@@ -377,5 +378,6 @@ inline auto StringTable::Get() -> auto& {
 }
 
 auto RaiseCatastrophicError(RemoteHandle<v8::Function>& handler, const char* message) -> bool;
+void ReportUnhandledRejection(RemoteHandle<v8::Function>& handler, std::unique_ptr<ExternalCopy> error);
 
 } // namespace ivm

--- a/src/isolate/strings.h
+++ b/src/isolate/strings.h
@@ -72,6 +72,7 @@ class StringTable {
 		String number{"number"};
 		String object{"object"};
 		String onCatastrophicError{"onCatastrophicError"};
+		String onUnhandledRejection{"onUnhandledRejection"};
 		String produceCachedData{"produceCachedData"};
 		String promise{"promise"};
 		String reference{"reference"};

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -72,6 +72,7 @@ auto IsolateHandle::Definition() -> Local<FunctionTemplate> {
 auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHandle> {
 	shared_ptr<v8::BackingStore> snapshot_blob;
 	RemoteHandle<Function> error_handler;
+	RemoteHandle<Function> rejection_handler;
 	size_t snapshot_blob_length = 0;
 	size_t memory_limit = 128;
 	bool inspector = false;
@@ -111,6 +112,12 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 		if (maybe_handler.ToLocal(&error_handler_local)) {
 			error_handler = RemoteHandle<Function>{error_handler_local};
 		}
+
+		auto maybe_rejection_handler = ReadOption<MaybeLocal<Function>>(options, StringTable::Get().onUnhandledRejection, {});
+		Local<Function> rejection_handler_local;
+		if (maybe_rejection_handler.ToLocal(&rejection_handler_local)) {
+			rejection_handler = RemoteHandle<Function>{rejection_handler_local};
+		}
 	}
 
 	// Return isolate handle
@@ -118,6 +125,7 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 	auto env = holder->GetIsolate();
 	env->GetIsolate()->SetHostInitializeImportMetaObjectCallback(ModuleHandle::InitializeImportMeta);
 	env->error_handler = error_handler;
+	env->unhandled_rejection_handler = rejection_handler;
 	if (inspector) {
 		env->EnableInspectorAgent();
 	}

--- a/tests/promise-unhandled-rejection.js
+++ b/tests/promise-unhandled-rejection.js
@@ -1,0 +1,71 @@
+const ivm = require('isolated-vm');
+const assert = require('assert');
+
+(async function() {
+	// Without a handler the rejection is thrown out of whichever call is running at the time
+	const bare = new ivm.Isolate;
+	const bareContext = await bare.createContext();
+	await assert.rejects(
+		bareContext.eval(`Promise.reject(new Error('nobody listens'))`),
+		/nobody listens/);
+	bare.dispose();
+
+	// A rejection which surfaces between calls is thrown out of the next call, however unrelated
+	const plain = new ivm.Isolate;
+	const plainContext = await plain.createContext();
+	await plainContext.evalClosure(
+		`globalThis.run = () => {
+			void $0.apply(undefined, [], { result: { promise: true } }).then(() => { throw new Error('late'); });
+		}`,
+		[ () => new Promise(resolve => setTimeout(resolve, 20)) ],
+		{ arguments: { reference: true } });
+	await plainContext.eval('run()');
+	await new Promise(resolve => setTimeout(resolve, 100));
+	await assert.rejects(plainContext.eval('1 + 1'), /late/);
+	plain.dispose();
+
+	// With a handler the calls are left alone and every rejected value reaches the handler
+	const seen = [];
+	const isolate = new ivm.Isolate({ onUnhandledRejection: error => seen.push(error) });
+	const context = await isolate.createContext();
+	await assert.doesNotReject(
+		context.eval(`Promise.reject(new Error('first')); Promise.reject(new Error('second'))`));
+	await context.evalClosure(
+		`globalThis.run = () => {
+			void $0.apply(undefined, [], { result: { promise: true } }).then(() => { throw new Error('late'); });
+		}`,
+		[ () => new Promise(resolve => setTimeout(resolve, 20)) ],
+		{ arguments: { reference: true } });
+	await context.eval('run()');
+	await new Promise(resolve => setTimeout(resolve, 100));
+	assert.strictEqual(await context.eval('1 + 1'), 2);
+	isolate.dispose();
+
+	await new Promise(resolve => setTimeout(resolve, 100));
+	assert.deepStrictEqual(seen.map(error => error.message), [ 'first', 'second', 'late' ]);
+
+	// A handler which throws has nobody left to report to, so it is ignored
+	const throwing = new ivm.Isolate({ onUnhandledRejection: () => { throw new Error('from the handler') } });
+	const throwingContext = await throwing.createContext();
+	await assert.doesNotReject(throwingContext.eval(`Promise.reject(new Error('third'))`));
+	await new Promise(resolve => setTimeout(resolve, 100));
+	assert.strictEqual(await throwingContext.eval('1 + 1'), 2);
+	throwing.dispose();
+
+	// A handler may live in another isolate rather than in node and receives the value the same way
+	const outer = new ivm.Isolate;
+	const outerContext = await outer.createContext();
+	outerContext.global.setSync('ivm', ivm);
+	await outerContext.eval(`(async () => {
+		globalThis.seen = [];
+		const inner = new ivm.Isolate({ onUnhandledRejection: error => seen.push(error.message) });
+		const innerContext = await inner.createContext();
+		await innerContext.eval('Promise.reject(new Error("nested"))');
+		inner.dispose();
+	})()`, { promise: true });
+	await new Promise(resolve => setTimeout(resolve, 100));
+	assert.strictEqual(await outerContext.eval('seen.join()'), 'nested');
+	outer.dispose();
+
+	console.log('pass');
+})().catch(console.error);


### PR DESCRIPTION
## Problem

A promise rejected with no handler inside an isolate is thrown out of whichever call happens to be running when the rejection surfaces. When user code fires a promise and forgets it, the rejection often surfaces during a later task, and then a completely unrelated `eval` fails with an error from code it never ran, with a stack trace pointing nowhere useful (#273). There is no other way to observe these rejections (#455), and since only one value can be thrown per task, everything past the first is silently lost.

## Repro

```js
// main.mjs, the last eval rejects with "forgotten" instead of returning 2
import ivm from 'isolated-vm';

const isolate = new ivm.Isolate();
const context = await isolate.createContext();
await context.evalClosure(
	'defer = fn => $0.apply(undefined, [], { result: { promise: true } }).then(fn)',
	[ () => new Promise(resolve => setTimeout(resolve, 10)) ],
	{ arguments: { reference: true } });

await context.eval('defer(() => { throw new Error("forgotten"); })');
await new Promise(resolve => setTimeout(resolve, 50));
console.log(await context.eval('1 + 1'));
```

## Fix

Adds an isolate option, `onUnhandledRejection`, built the way `onCatastrophicError` is: read from the constructor options, kept on the environment, called through a task on the isolate that created this one. When it is set nothing is thrown; the callback receives each rejected value, copied out like a thrown value, stack trace included. A callback that throws is ignored, since there is nobody left to tell. Without the option nothing changes.

Also adds a regression test which fails on master: the default throw, the poisoned unrelated call, several rejections in one task all reaching the callback, a throwing callback, and a callback registered from inside another isolate. README and the type declarations document the option.
