### PR TITLE
Add `importModuleDynamically` isolate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ contains can represent quite a large chunk of memory though you may want to expl
     handler. By default such a rejection is thrown out of whichever call into the isolate happens to
     be running, which may be one unrelated to the promise. If this callback is set the rejected value
     is passed to it instead and nothing is thrown. Errors thrown by the callback are ignored.
+  * `importModuleDynamically` *[function]* - Callback which resolves `import()` for the code this
+    isolate runs. It accepts two parameters: `specifier` and `referrer`, the `filename` used in
+    [`ScriptOrigin`](#scriptorigin) by the script or module which called `import()`. It must return
+    a `Module` which has been instantiated and evaluated, or a promise for one, since the importing
+    code is given that module's namespace. Nothing is cached, so answer the same specifier with the
+    same module. Without this option `import()` rejects with "Not supported".
 
 *NOTE*: `snapshot` contains compiled machine code. That means you should not accept `snapshot`
 payloads from a user, otherwise they may be able to run arbitrary code.

--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -166,6 +166,16 @@ declare namespace IsolatedVM {
 		 * callback are ignored.
 		 */
 		onUnhandledRejection?: (error: any) => void;
+
+		/**
+		 * Callback which resolves `import()` for the code this isolate runs. It accepts two parameters:
+		 * `specifier` and `referrer`, the `filename` given in the `ScriptOrigin` of the script or module
+		 * which called `import()`. It must return a `Module` which has been instantiated and evaluated,
+		 * or a promise for one, since the importing code is given that module's namespace. Nothing is
+		 * cached, so answer the same specifier with the same module. Without this option `import()`
+		 * rejects with "Not supported".
+		 */
+		importModuleDynamically?: (specifier: string, referrer: string) => Module | Promise<Module>;
 	};
 
 	export type ContextOptions = {

--- a/src/isolate/environment.h
+++ b/src/isolate/environment.h
@@ -118,6 +118,7 @@ class IsolateEnvironment : public std::enable_shared_from_this<IsolateEnvironmen
 	public:
 		RemoteHandle<v8::Function> error_handler;
 		RemoteHandle<v8::Function> unhandled_rejection_handler;
+		RemoteHandle<v8::Function> dynamic_import_handler;
 		std::unordered_multimap<int, struct ModuleInfo*> module_handles;
 		std::unordered_map<class NativeModule*, std::shared_ptr<NativeModule>> native_modules;
 		int terminate_depth = 0;

--- a/src/isolate/strings.h
+++ b/src/isolate/strings.h
@@ -60,6 +60,7 @@ class StringTable {
 		String function{"function"};
 		String global{"global"};
 		String ignored{"ignored"};
+		String importModuleDynamically{"importModuleDynamically"};
 		String inspector{"inspector"};
 		String isolateIsDisposed{"Isolate is disposed"};
 		String isolatedVm{"isolated-vm"};

--- a/src/module/isolate_handle.cc
+++ b/src/module/isolate_handle.cc
@@ -73,6 +73,7 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 	shared_ptr<v8::BackingStore> snapshot_blob;
 	RemoteHandle<Function> error_handler;
 	RemoteHandle<Function> rejection_handler;
+	RemoteHandle<Function> dynamic_import_handler;
 	size_t snapshot_blob_length = 0;
 	size_t memory_limit = 128;
 	bool inspector = false;
@@ -118,6 +119,12 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 		if (maybe_rejection_handler.ToLocal(&rejection_handler_local)) {
 			rejection_handler = RemoteHandle<Function>{rejection_handler_local};
 		}
+
+		auto maybe_import_handler = ReadOption<MaybeLocal<Function>>(options, StringTable::Get().importModuleDynamically, {});
+		Local<Function> import_handler_local;
+		if (maybe_import_handler.ToLocal(&import_handler_local)) {
+			dynamic_import_handler = RemoteHandle<Function>{import_handler_local};
+		}
 	}
 
 	// Return isolate handle
@@ -126,6 +133,12 @@ auto IsolateHandle::New(MaybeLocal<Object> maybe_options) -> unique_ptr<ClassHan
 	env->GetIsolate()->SetHostInitializeImportMetaObjectCallback(ModuleHandle::InitializeImportMeta);
 	env->error_handler = error_handler;
 	env->unhandled_rejection_handler = rejection_handler;
+	// An isolate without a handler never gets the callback, so its `import()` keeps rejecting with
+	// the "Not supported" error v8 raises on its own
+	if (dynamic_import_handler) {
+		env->dynamic_import_handler = std::move(dynamic_import_handler);
+		env->GetIsolate()->SetHostImportModuleDynamicallyCallback(ModuleHandle::ImportModuleDynamically);
+	}
 	if (inspector) {
 		env->EnableInspectorAgent();
 	}

--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -120,6 +120,99 @@ void ModuleHandle::InitializeImportMeta(Local<Context> context, Local<Module> mo
 }
 
 /**
+ * Runs the handler which answers `import()`, in the isolate that registered it. The handler is
+ * given the specifier and the importer's resource name, and answers with the module that specifier
+ * names, or with a promise for one.
+ */
+struct DynamicImportRunner : public ThreePhaseTask {
+	RemoteHandle<Function> handler;
+	std::string specifier;
+	std::string referrer;
+	std::unique_ptr<Transferable> module_handle;
+
+	DynamicImportRunner(RemoteHandle<Function> handler, Local<String> specifier, Local<Value> resource_name) :
+		handler{std::move(handler)},
+		specifier{HandleCast<std::string>(specifier)},
+		referrer{HandleCast<std::string>(resource_name)} {}
+
+	void Phase2() final {
+		auto* isolate = Isolate::GetCurrent();
+		auto& env = IsolateEnvironment::GetCurrent();
+		Local<Context> context = env.DefaultContext();
+		Context::Scope context_scope{context};
+		Local<Value> argv[2];
+		argv[0] = HandleCast<Local<String>>(specifier);
+		argv[1] = HandleCast<Local<String>>(referrer);
+		auto maybe_value = handler.Deref()->Call(context, Undefined(isolate), 2, argv);
+		if (env.DidHitMemoryLimit()) {
+			throw FatalRuntimeError("Isolate was disposed during execution due to memory limit");
+		} else if (env.terminated) {
+			throw FatalRuntimeError("Isolate was disposed during execution");
+		}
+		TransferOptions options;
+		options.promise = true;
+		module_handle = TransferOut(Unmaybe(maybe_value), options);
+	}
+
+	auto Phase3() -> Local<Value> final {
+		return module_handle->TransferIn();
+	}
+};
+
+namespace {
+
+/**
+ * A module namespace cannot leave the isolate which holds the module, so the handler answers with
+ * the module and the namespace is taken here, once it has crossed back.
+ */
+auto GetModuleNamespace(Local<Value> value) -> Local<Value> {
+	auto* module = value->IsObject() ? ClassHandle::Unwrap<ModuleHandle>(value.As<Object>()) : nullptr;
+	if (module == nullptr) {
+		throw RuntimeTypeError("Resolved import was not `Module`");
+	}
+	auto info = module->GetInfo();
+	if (info->handle.GetSharedIsolateHolder() != IsolateEnvironment::GetCurrentHolder()) {
+		throw RuntimeGenericError("Module is from a different isolate");
+	}
+	Local<Module> mod = info->handle.Deref();
+	auto status = mod->GetStatus();
+	if (status == Module::Status::kErrored) {
+		Isolate::GetCurrent()->ThrowException(mod->GetException());
+		throw RuntimeError();
+	}
+	// A module which is still evaluating hands over the bindings it has so far, the same as a cycle
+	// sees anywhere else
+	if (status != Module::Status::kEvaluating && status != Module::Status::kEvaluated) {
+		throw RuntimeGenericError("Module has not been evaluated");
+	}
+	return mod->GetModuleNamespace();
+}
+
+} // anonymous namespace
+
+/**
+ * Invoked by v8 for each `import()` in an isolate whose embedder registered a handler.
+ */
+auto ModuleHandle::ImportModuleDynamically(
+	Local<Context> context,
+	Local<Data> /*host_defined_options*/,
+	Local<Value> resource_name,
+	Local<String> specifier,
+	Local<FixedArray> /*import_attributes*/
+) -> MaybeLocal<Promise> {
+	MaybeLocal<Promise> ret;
+	detail::RunBarrier([&]() {
+		auto& handler = IsolateEnvironment::GetCurrent().dynamic_import_handler;
+		Local<Value> module = ThreePhaseTask::Run<1, DynamicImportRunner>(
+			*handler.GetIsolateHolder(), handler, specifier, resource_name);
+		ret = Unmaybe(module.As<Promise>()->Then(context, Unmaybe(
+			Function::New(context, FreeFunction<decltype(&GetModuleNamespace), &GetModuleNamespace>{}.callback)
+		)));
+	});
+	return ret;
+}
+
+/**
  * Implements the module linking logic used by `instantiate`. This is implemented as a class handle
  * so v8 can manage the lifetime of the linker. If a promise fails to resolve then v8 will be
  * responsible for calling the destructor.

--- a/src/module/module_handle.h
+++ b/src/module/module_handle.h
@@ -63,6 +63,13 @@ class ModuleHandle : public TransferableHandle {
 		auto GetNamespace() -> v8::Local<v8::Value>;
 
 		static void InitializeImportMeta(v8::Local<v8::Context> context, v8::Local<v8::Module> module, v8::Local<v8::Object> meta);
+		static auto ImportModuleDynamically(
+			v8::Local<v8::Context> context,
+			v8::Local<v8::Data> host_defined_options,
+			v8::Local<v8::Value> resource_name,
+			v8::Local<v8::String> specifier,
+			v8::Local<v8::FixedArray> import_attributes
+		) -> v8::MaybeLocal<v8::Promise>;
 };
 
 } // namespace ivm

--- a/tests/module-dynamic-import.js
+++ b/tests/module-dynamic-import.js
@@ -1,0 +1,119 @@
+const ivm = require('isolated-vm');
+const assert = require('assert');
+
+(async function() {
+	// Without a handler `import()` rejects with the error v8 raises on its own
+	const bare = new ivm.Isolate;
+	const bareContext = await bare.createContext();
+	await assert.rejects(bareContext.eval(`import('./add.js')`, { promise: true }), /Not supported/);
+	bare.dispose();
+
+	const seen = [];
+	const modules = new Map;
+	const isolate = new ivm.Isolate({
+		importModuleDynamically(specifier, referrer) {
+			seen.push([ specifier, referrer ]);
+			if (specifier === './boom.js') {
+				throw new Error('boom');
+			}
+			return modules.get(specifier);
+		},
+	});
+	const context = await isolate.createContext();
+	const add = await isolate.compileModule(
+		`export const name = 'add'; export default (left, right) => left + right;`,
+		{ filename: 'file:///add.js' });
+	await add.instantiate(context, () => {});
+	await add.evaluate();
+	modules.set('./add.js', add);
+
+	// The handler answers with a module and the isolate receives that module's namespace
+	assert.strictEqual(await context.eval(`import('./add.js').then(ns => ns.name)`, { promise: true }), 'add');
+	assert.deepStrictEqual(seen.at(-1), [ './add.js', '<isolated-vm>' ]);
+
+	// A module gets its own filename as the referrer, and the bindings it receives are usable
+	const main = await isolate.compileModule(
+		`export const load = () => import('./add.js');`,
+		{ filename: 'file:///main.js' });
+	await main.instantiate(context, () => {});
+	await main.evaluate();
+	const load = await main.namespace.get('load', { reference: true });
+	const namespace = await load.apply(undefined, [], { result: { promise: true, reference: true } });
+	assert.deepStrictEqual(seen.at(-1), [ './add.js', 'file:///main.js' ]);
+	// The exports of a namespace are accessors, so reading one from here needs `accessors`
+	const exported = await namespace.get('default', { accessors: true, reference: true });
+	assert.strictEqual(await exported.apply(undefined, [ 2, 4 ]), 6);
+
+	// The handler may answer with a promise, like the callback which resolves static dependencies
+	modules.set('./add-later.js', Promise.resolve(add));
+	assert.strictEqual(await context.eval(`import('./add-later.js').then(ns => ns.name)`, { promise: true }), 'add');
+
+	// A specifier reaches the handler exactly as the isolate wrote it
+	modules.set('./café-中.js', add);
+	assert.strictEqual(await context.eval(`import('./café-中.js').then(ns => ns.name)`, { promise: true }), 'add');
+	assert.deepStrictEqual(seen.at(-1), [ './café-中.js', '<isolated-vm>' ]);
+
+	// The isolate sees what the handler throws
+	await assert.rejects(context.eval(`import('./boom.js')`, { promise: true }), /boom/);
+
+	// A specifier the handler has no module for rejects in the isolate
+	await assert.rejects(context.eval(`import('./nope.js')`, { promise: true }), /Resolved import was not `Module`/);
+
+	// A module which has not been evaluated has no bindings to hand over, and one which has not been
+	// instantiated has no namespace at all
+	const unevaluated = await isolate.compileModule(`export const name = 'unevaluated';`);
+	await unevaluated.instantiate(context, () => {});
+	modules.set('./unevaluated.js', unevaluated);
+	await assert.rejects(context.eval(`import('./unevaluated.js')`, { promise: true }), /Module has not been evaluated/);
+	modules.set('./uninstantiated.js', await isolate.compileModule(`export const name = 'uninstantiated';`));
+	await assert.rejects(context.eval(`import('./uninstantiated.js')`, { promise: true }), /Module has not been evaluated/);
+
+	// A module which failed to evaluate rejects with the error it threw
+	const failed = await isolate.compileModule(`throw new Error('module failed');`);
+	await failed.instantiate(context, () => {});
+	await assert.rejects(failed.evaluate(), /module failed/);
+	modules.set('./failed.js', failed);
+	await assert.rejects(context.eval(`import('./failed.js')`, { promise: true }), /module failed/);
+
+	// A namespace belongs to the isolate its module was compiled in and can go nowhere else
+	const other = new ivm.Isolate;
+	const otherContext = await other.createContext();
+	const otherModule = await other.compileModule(`export const name = 'other';`);
+	await otherModule.instantiate(otherContext, () => {});
+	await otherModule.evaluate();
+	modules.set('./other.js', otherModule);
+	await assert.rejects(context.eval(`import('./other.js')`, { promise: true }), /Module is from a different isolate/);
+	other.dispose();
+
+	isolate.dispose();
+
+	// A handler may belong to another isolate rather than to nodejs, and it is called there
+	const outer = new ivm.Isolate;
+	const outerContext = await outer.createContext();
+	outerContext.global.setSync('ivm', ivm);
+	assert.strictEqual(await outerContext.eval(`(async () => {
+		const modules = new Map;
+		const inner = new ivm.Isolate({ importModuleDynamically: specifier => modules.get(specifier) });
+		const innerContext = await inner.createContext();
+		const nested = await inner.compileModule('export const name = "nested";');
+		await nested.instantiate(innerContext, () => {});
+		await nested.evaluate();
+		modules.set('./nested.js', nested);
+		return innerContext.eval('import("./nested.js").then(ns => ns.name)', { promise: true });
+	})()`, { promise: true }), 'nested');
+	outer.dispose();
+
+	// A handler whose own isolate dies while it runs reports why
+	const starving = new ivm.Isolate({ memoryLimit: 16 });
+	const starvingContext = await starving.createContext();
+	starvingContext.global.setSync('ivm', ivm);
+	const starved = await starvingContext.eval(`
+		const waste = [];
+		new ivm.Isolate({ importModuleDynamically: () => { for (;;) waste.push(new Array(1e5).fill(0)) } });
+	`);
+	const starvedContext = await starved.createContext();
+	await assert.rejects(starvedContext.eval(`import('./starved.js')`, { promise: true }), /memory limit/);
+	starved.dispose();
+
+	console.log('pass');
+})().catch(console.error);


### PR DESCRIPTION
Adds an isolate option, `importModuleDynamically`, which installs v8's dynamic import callback and hands each `import()` to the host: it gets the specifier, and answers with a module it compiled itself, the same contract `module.instantiate` gives its `resolveCallback`. Until it's set `import()` rejects with `Not supported` (#199, #130).

## Usage

```js
// main.mjs, rejects with "Not supported" on main, prints "hello from a module" with this change
import ivm from 'isolated-vm';

const modules = new Map();
const isolate = new ivm.Isolate({
	importModuleDynamically: specifier => modules.get(specifier),
});
const context = await isolate.createContext();

const greeting = await isolate.compileModule('export const message = "hello from a module";');
await greeting.instantiate(context, specifier => modules.get(specifier));
await greeting.evaluate();
modules.set('./greeting.js', greeting);

console.log(await context.eval('import("./greeting.js").then(ns => ns.message)', { promise: true }));
```

## Implementation

The callback only reaches v8 when the option is set, so without it nothing changes.

An `import()` runs the handler through a `ThreePhaseTask` on the isolate that registered it, the same as any other call across the boundary: it receives the specifier and the `filename` from the importer's `ScriptOrigin`, the importing isolate keeps running while it works, and the answer crosses back the way a promise result does, so the handler may return the module or a promise for it.

A namespace object cannot leave the isolate that owns it, so the handler answers with the module and the namespace is read on the importing side once it lands. Evaluating stays with the host, so guest code runs inside the `timeout` it passes to `evaluate`. The isolate never supplies anything but the specifier.

An answer that is not a `Module` rejects the import, and so does a module from another isolate, which would otherwise hand its exports to the importing isolate through the namespace. A module that has not been evaluated rejects too, since its bindings are not initialized, and one that was never instantiated would take the process down inside `v8::Module::GetModuleNamespace`. If evaluation threw, the import rejects with that error.

Also adds a regression test which fails on main: the rejection with no handler, imports from a script and from a module, a promise answer, a handler that throws, each of the refusals above, a handler that lives in another isolate, and one whose isolate dies mid-call. README and the type declarations document the option.
