### PR TITLE
Honor `promise` transfer option in `module.evaluate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ module will have no effect.
 * `options` *[object]* - Optional.
 	* `timeout` *[number]* - Maximum amount of time in milliseconds this module is allowed to
 	run before execution is canceled. Default is no timeout.
+	* `promise` *[boolean]* - Resolve once the module has finished running rather than when it
+	first yields, and reject with the error it threw along the way. `evaluateSync` returns a
+	promise when this option is set, even for an error thrown before the first yield. `timeout`
+	covers only the run up to the first yield. The other transfer options are ignored.
 * **return** *[transferable]*
 
 Evaluate the module and return the last expression (same as script.run). If `evaluate` is called
@@ -416,7 +420,8 @@ more than once on the same module the return value from the first invocation wil
 thrown).
 
 **Note:** nodejs v14.8.0 enabled top-level await by default which has the effect of breaking the
-return value of this function.
+return value of this function. With `promise: true` the call waits for such a module to finish.
+The resolved value is still `undefined`: v8 fulfills the evaluation promise with no value.
 
 ##### `module.release()`
 

--- a/isolated-vm.d.ts
+++ b/isolated-vm.d.ts
@@ -321,11 +321,13 @@ declare namespace IsolatedVM {
 		/**
 		 * Evaluate the module and return the last expression (same as script.run). If evaluate is
 		 * called more than once on the same module the return value from the first invocation will be
-		 * returned (or thrown).
+		 * returned (or thrown). A module which awaits at the top level keeps running after evaluate
+		 * resolves. With `promise: true` the call resolves once the module has finished, and rejects
+		 * with the error it threw.
 		 * @param options Optional
 		 */
 		evaluate(options?: ScriptRunOptions): Promise<Transferable>;
-		evaluateSync(options?: ScriptRunOptions): Transferable;
+		evaluateSync<Options extends ScriptRunOptions>(options?: Options): CheckPromise<Options, Transferable>;
 
 		/**
 		 * Releases this module. This behaves the same as other `.release()` methods.

--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -453,8 +453,13 @@ struct EvaluateRunner : public ThreePhaseTask {
 	shared_ptr<ModuleInfo> info;
 	std::unique_ptr<Transferable> result;
 	uint32_t timeout;
+	TransferOptions transfer_options;
 
-	EvaluateRunner(shared_ptr<ModuleInfo> info, uint32_t ms) : info(std::move(info)), timeout(ms) {}
+	EvaluateRunner(shared_ptr<ModuleInfo> info, uint32_t ms, bool promise) : info(std::move(info)), timeout(ms) {
+		// The evaluation promise is the only signal that a module which awaits at the top level has
+		// finished.
+		transfer_options.promise = promise;
+	}
 
 	void Phase2() final {
 		Local<Module> mod = info->handle.Deref();
@@ -463,7 +468,7 @@ struct EvaluateRunner : public ThreePhaseTask {
 		}
 		Local<Context> context_local = Deref(info->context_handle);
 		Context::Scope context_scope(context_local);
-		result = OptionalTransferOut(RunWithTimeout(timeout, [&]() { return mod->Evaluate(context_local); }));
+		result = OptionalTransferOut(RunWithTimeout(timeout, [&]() { return mod->Evaluate(context_local); }), transfer_options);
 		std::lock_guard<std::mutex> lock(info->mutex);
 		info->global_namespace = RemoteHandle<Value>(mod->GetModuleNamespace());
 	}
@@ -481,7 +486,8 @@ template <int async>
 auto ModuleHandle::Evaluate(MaybeLocal<Object> maybe_options) -> Local<Value> {
 	auto info = GetInfo();
 	int32_t timeout_ms = ReadOption<int32_t>(maybe_options, StringTable::Get().timeout, 0);
-	return ThreePhaseTask::Run<async, EvaluateRunner>(*info->handle.GetIsolateHolder(), info, timeout_ms);
+	bool promise = ReadOption<bool>(maybe_options, StringTable::Get().promise, false);
+	return ThreePhaseTask::Run<async, EvaluateRunner>(*info->handle.GetIsolateHolder(), info, timeout_ms, promise);
 }
 
 auto ModuleHandle::GetNamespace() -> Local<Value> {

--- a/tests/module-evaluate-promise.js
+++ b/tests/module-evaluate-promise.js
@@ -1,0 +1,124 @@
+const ivm = require('isolated-vm');
+const { strictEqual } = require('assert');
+
+(async function() {
+	const isolate = new ivm.Isolate();
+	const context = await isolate.createContext();
+
+	// A module which finishes synchronously settles right away, and the value is
+	// undefined: the evaluation promise fulfills with no value.
+	{
+		const module = await isolate.compileModule('globalThis.ran = true;');
+		await module.instantiate(context, () => {});
+		strictEqual(await module.evaluate({ promise: true }), undefined);
+		strictEqual(await context.global.get('ran'), true);
+	}
+
+	// Without the option `evaluate` still resolves when the module yields.
+	{
+		const module = await isolate.compileModule(
+			'await new Promise(resolve => globalThis.wake1 = resolve); globalThis.finished1 = true;');
+		await module.instantiate(context, () => {});
+		strictEqual(await module.evaluate(), undefined);
+		strictEqual(await context.global.get('finished1'), undefined);
+	}
+
+	// With the option `evaluate` resolves once the module has finished.
+	{
+		const module = await isolate.compileModule(
+			'await new Promise(resolve => globalThis.wake2 = resolve); globalThis.finished2 = true;');
+		await module.instantiate(context, () => {});
+		let woke = false;
+		const settled = module.evaluate({ promise: true }).then(() => strictEqual(woke, true));
+		// Without this catch an assertion failure surfaces as an unhandled rejection
+		// before the await below reads it.
+		settled.catch(() => {});
+		await new Promise(resolve => setTimeout(resolve, 100));
+		woke = true;
+		await context.eval('wake2()');
+		await settled;
+		strictEqual(await context.global.get('finished2'), true);
+	}
+
+	// A throw after the first yield rejects `evaluate` with the module's own error.
+	{
+		const module = await isolate.compileModule(
+			'await new Promise(resolve => globalThis.wake3 = resolve); throw new Error("late failure");');
+		await module.instantiate(context, () => {});
+		const settled = module.evaluate({ promise: true }).then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'late failure'));
+		await new Promise(resolve => setTimeout(resolve, 100));
+		await context.eval('wake3()');
+		await settled;
+	}
+
+	// `evaluateSync` returns a promise which settles the same way.
+	{
+		const module = await isolate.compileModule(
+			'await new Promise(resolve => globalThis.wake4 = resolve); globalThis.finished4 = true;');
+		await module.instantiate(context, () => {});
+		let woke = false;
+		const settled = module.evaluateSync({ promise: true }).then(() => strictEqual(woke, true));
+		settled.catch(() => {});
+		await new Promise(resolve => setTimeout(resolve, 100));
+		woke = true;
+		await context.eval('wake4()');
+		await settled;
+		strictEqual(await context.global.get('finished4'), true);
+	}
+
+	// A throw before the first yield rejects the returned promise; the call itself
+	// throws nothing.
+	{
+		const module = await isolate.compileModule('throw new Error("early failure");');
+		await module.instantiate(context, () => {});
+		await module.evaluateSync({ promise: true }).then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'early failure'));
+	}
+
+	// The timeout still bounds the run up to the first yield.
+	{
+		const module = await isolate.compileModule('let i = 0; while (++i); i;');
+		await module.instantiate(context, () => {});
+		await module.evaluate({ timeout: 50, promise: true }).then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'Script execution timed out.'));
+	}
+
+	// Repeat calls answer with the first invocation's outcome, while the module
+	// is still running and after it has failed.
+	{
+		const module = await isolate.compileModule(
+			'await new Promise(resolve => globalThis.wake5 = resolve); throw new Error("repeated failure");');
+		await module.instantiate(context, () => {});
+		const outcomes = [
+			module.evaluate({ promise: true }),
+			module.evaluate({ promise: true }),
+		].map(settled => settled.then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'repeated failure')));
+		await context.eval('wake5()');
+		await Promise.all(outcomes);
+		await module.evaluate({ promise: true }).then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'repeated failure'));
+	}
+
+	// Disposing the isolate rejects a pending settlement.
+	{
+		const other = new ivm.Isolate();
+		const otherContext = await other.createContext();
+		const module = await other.compileModule('await new Promise(() => {});');
+		await module.instantiate(otherContext, () => {});
+		const settled = module.evaluate({ promise: true }).then(
+			() => { throw new Error('Promise did not reject') },
+			error => strictEqual(error.message, 'Promise was abandoned'));
+		await new Promise(resolve => setTimeout(resolve, 100));
+		other.dispose();
+		await settled;
+	}
+
+	console.log('pass');
+})().catch(console.error);


### PR DESCRIPTION
## Problem

A module which awaits at the top level keeps running after `evaluate` resolves. `Module::Evaluate` returns the evaluation promise, `evaluate` drops it and resolves `undefined` at the module's first yield: there is no way to learn that the module finished (#494), and an error thrown after the first yield surfaces as an unhandled rejection out of whichever call runs next instead of reaching the caller. `evaluate` already accepts `promise: true` through `ScriptRunOptions` and ignores it.

## Repro

```js
// main.mjs, prints "evaluate settled: undefined" instead of rejecting with "late failure"
import ivm from 'isolated-vm';

const isolate = new ivm.Isolate();
const context = await isolate.createContext();
const module = await isolate.compileModule(`
	await new Promise(resolve => { globalThis.wake = resolve; });
	throw new Error('late failure');
`);
await module.instantiate(context, () => {});
setTimeout(() => context.evalIgnored('wake()'), 50);
try {
	console.log('evaluate settled:', await module.evaluate({ promise: true }));
} catch (error) {
	console.log(error.message);
}
```

## Fix

`evaluate` now honors the `promise` transfer option: `EvaluateRunner` passes it through to `OptionalTransferOut`, so the evaluation promise crosses the same way a promise returned from `script.run(context, { promise: true })` does. The call resolves once the module has finished and rejects with the error the module threw. The resolved value is still `undefined`, since v8 fulfills the evaluation promise with no value (#332). Only `promise` is read: honoring `copy` or `reference` here would change what existing callers get back. Without the option nothing changes. `evaluateSync({ promise: true })` returns a promise, the way `runSync` does.

Also adds a regression test which fails on master: settlement after the module finishes, a throw after the first yield delivered as the rejection, a throw before the first yield rejecting the promise `evaluateSync` returns, repeat calls answering with the first invocation's outcome, and `Promise was abandoned` on disposal mid-wait. README and the type declarations document the option, and `evaluateSync` picks up the `CheckPromise` return type.
