### PR TITLE
Fix mangled non-ASCII module specifiers

### DIFF
--- a/src/module/module_handle.cc
+++ b/src/module/module_handle.cc
@@ -89,7 +89,7 @@ auto ModuleHandle::GetDependencySpecifiers() -> Local<Value> {
 	size_t length = info->dependency_specifiers.size();
 	Local<Array> deps = Array::New(isolate, length);
 	for (size_t ii = 0; ii < length; ++ii) {
-		Unmaybe(deps->Set(isolate->GetCurrentContext(), ii, v8_string(info->dependency_specifiers[ii].c_str())));
+		Unmaybe(deps->Set(isolate->GetCurrentContext(), ii, HandleCast<Local<String>>(info->dependency_specifiers[ii])));
 	}
 	return deps;
 }
@@ -308,7 +308,7 @@ class ModuleLinker : public ClassHandle {
 			argv[1] = module->This();
 			Local<Function> fn = callback.Deref();
 			for (size_t ii = 0; ii < info->dependency_specifiers.size(); ++ii) {
-				argv[0] = v8_string(info->dependency_specifiers[ii].c_str());
+				argv[0] = HandleCast<Local<String>>(info->dependency_specifiers[ii]);
 				impl->HandleCallbackReturn(module, ii, Unmaybe(fn->Call(context, recv, 2, argv)));
 			}
 		}

--- a/tests/module-specifier-utf8.js
+++ b/tests/module-specifier-utf8.js
@@ -1,0 +1,20 @@
+const ivm = require('isolated-vm');
+const { strictEqual } = require('assert');
+
+(async function() {
+	const isolate = new ivm.Isolate();
+	const context = await isolate.createContext();
+	const specifier = './café-中-😀.js';
+	const root = await isolate.compileModule(`import value from '${specifier}'; globalThis.value = value;`);
+	const dependency = await isolate.compileModule('export default 42;');
+
+	strictEqual(root.dependencySpecifiers[0], specifier);
+	await root.instantiate(context, received => {
+		strictEqual(received, specifier);
+		return dependency;
+	});
+	await root.evaluate();
+	strictEqual(await context.global.get('value'), 42);
+
+	console.log('pass');
+})().catch(err => { console.error(err); });


### PR DESCRIPTION
## Problem

`ModuleInfo` stores the dependency specifiers as UTF-8, and the two places that hand them back to JavaScript, `module.dependencySpecifiers` and the resolve callback of `instantiate`, build the string with `v8_string`, so the UTF-8 bytes go through the one-byte constructor. `import './café.js'` shows up as `./cafÃ©.js` on both, and a callback that looks the module up by the name the source used finds nothing. Linking itself still works, because `resolutions` and `ResolveCallback` compare the same UTF-8 bytes on both sides; only what JavaScript sees is wrong.

## Repro

```js
// main.mjs, both lines print ./cafÃ©.js
import ivm from 'isolated-vm';

const isolate = new ivm.Isolate();
const context = await isolate.createContext();
const module = await isolate.compileModule(`import './café.js';`);
console.log(module.dependencySpecifiers[0]);
await module.instantiate(context, specifier => {
	console.log(specifier);
	return isolate.compileModuleSync('');
});
```

## Fix

The fix builds those two strings through `HandleCast<Local<String>>`, so the stored bytes decode as UTF-8. Also adds a regression test which fails on master: one specifier with characters of two, three and four bytes, checked on the getter and on the resolve callback.
